### PR TITLE
Fix CSP for /home/about

### DIFF
--- a/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
@@ -131,7 +131,7 @@ namespace MartinCostello.Website.Middleware
 default-src 'self';
 script-src 'self' ajax.googleapis.com cdnjs.cloudflare.com maxcdn.bootstrapcdn.com platform.linkedin.com platform.twitter.com www.google-analytics.com www.openhub.net 'unsafe-inline';
 style-src 'self' ajax.googleapis.com fonts.googleapis.com maxcdn.bootstrapcdn.com 'unsafe-inline';
-img-src 'self' stackoverflow.com static.licdn.com syndication.twitter.com www.google-analytics.com www.openhub.net data:;
+img-src 'self' stackoverflow.com static.licdn.com syndication.twitter.com www.google-analytics.com www.linkedin.com www.openhub.net data:;
 font-src 'self' ajax.googleapis.com fonts.googleapis.com fonts.gstatic.com maxcdn.bootstrapcdn.com;
 connect-src 'self';
 media-src 'none';


### PR DESCRIPTION
Fix the Content Security Policy on the ```/home/about``` page by adding ```www.linkedin.com``` to the ```img-src``` to resolve #11.