### PR TITLE
Fix jquery.lazyload issues

### DIFF
--- a/src/Website/Views/Home/About.cshtml
+++ b/src/Website/Views/Home/About.cshtml
@@ -61,7 +61,7 @@
     <environment names="Staging,Production">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/@BowerVersions["jquery.lazyload"]/jquery.lazyload.min.js" integrity="" crossorigin="anonymous"
                 asp-fallback-src="~/lib/jquery.lazyload/jquery.lazyload.min.js"
-                asp-fallback-test="window.$.lazyload">
+                asp-fallback-test="window.$.fn.lazyload">
         </script>
     </environment>
     <script src="//platform.linkedin.com/in.js"></script>


### PR DESCRIPTION
Fix #13 and #17 by using the minified version of `jquery.lazyload`, and only using the local version from Bower when the CDN version does not load.
