### PR TITLE
Add missing subresource integrity hash

### DIFF
--- a/src/Website/Views/Shared/_Layout.cshtml
+++ b/src/Website/Views/Shared/_Layout.cshtml
@@ -77,7 +77,7 @@
             asp-fallback-src="~/lib/bootstrap/dist/js/bootstrap.min.js"
             asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal">
     </script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/@BowerVersions["jquery.lazyload"]/jquery.lazyload.min.js" integrity="" crossorigin="anonymous"
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/@BowerVersions["jquery.lazyload"]/jquery.lazyload.min.js" integrity="sha256-rXnOfjTRp4iAm7hTAxEz3irkXzwZrElV2uRsdJAYjC4=" crossorigin="anonymous"
             asp-fallback-src="~/lib/jquery.lazyload/jquery.lazyload.min.js"
             asp-fallback-test="window.$.fn.lazyload">
     </script>


### PR DESCRIPTION
Add the missing subresource integrity hash for ```jquery.lazyload.min.js``` to resolve #23.