### PR TITLE
Update content security policy

### DIFF
--- a/src/Website/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/Website/Extensions/IApplicationBuilderExtensions.cs
@@ -20,15 +20,17 @@ namespace MartinCostello.Website.Extensions
         /// <param name="value">The <see cref="IApplicationBuilder"/> to add the middleware to.</param>
         /// <param name="environment">The current hosting environment.</param>
         /// <param name="config">The current configuration.</param>
+        /// <param name="options">The current site options.</param>
         /// <returns>
         /// The value specified by <paramref name="value"/>.
         /// </returns>
         public static IApplicationBuilder UseCustomHttpHeaders(
             this IApplicationBuilder value,
             IHostingEnvironment environment,
-            IConfiguration config)
+            IConfiguration config,
+            SiteOptions options)
         {
-            return value.UseMiddleware<CustomHttpHeadersMiddleware>(environment, config);
+            return value.UseMiddleware<CustomHttpHeadersMiddleware>(environment, config, options);
         }
     }
 }

--- a/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
@@ -131,7 +131,7 @@ namespace MartinCostello.Website.Middleware
 default-src 'self';
 script-src 'self' ajax.googleapis.com cdnjs.cloudflare.com maxcdn.bootstrapcdn.com platform.linkedin.com platform.twitter.com www.google-analytics.com www.openhub.net 'unsafe-inline';
 style-src 'self' ajax.googleapis.com fonts.googleapis.com maxcdn.bootstrapcdn.com 'unsafe-inline';
-img-src 'self' stackoverflow.com static.licdn.com syndication.twitter.com www.google-analytics.com www.linkedin.com www.openhub.net data:;
+img-src 'self' stackoverflow.com static.licdn.com stats.g.doubleclick.net syndication.twitter.com www.google-analytics.com www.linkedin.com www.openhub.net data:;
 font-src 'self' ajax.googleapis.com fonts.googleapis.com fonts.gstatic.com maxcdn.bootstrapcdn.com;
 connect-src 'self';
 media-src 'none';

--- a/src/Website/Startup.cs
+++ b/src/Website/Startup.cs
@@ -72,7 +72,7 @@ namespace MartinCostello.Website
         {
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
 
-            app.UseCustomHttpHeaders(environment, Configuration);
+            app.UseCustomHttpHeaders(environment, Configuration, ServiceProvider.GetRequiredService<SiteOptions>());
 
             if (environment.IsDevelopment())
             {


### PR DESCRIPTION
Update the Content Security Policy to resolve an error from ```stats.g.doubleclick.net``` and to allow AJAX calls to ```api.martincostello.com```.