### PR TITLE
Link to exact line of code in GitHub from /projects

### DIFF
--- a/src/Website/Extensions/IRazorPageExtensions.cs
+++ b/src/Website/Extensions/IRazorPageExtensions.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Website.Extensions
+{
+    using System.Runtime.CompilerServices;
+    using Microsoft.AspNetCore.Mvc.Razor;
+
+    /// <summary>
+    /// A class containing extension methods for the <see cref="IRazorPage"/> interface. This class cannot be inherited.
+    /// </summary>
+    public static class IRazorPageExtensions
+    {
+        /// <summary>
+        /// Returns the current line number of the razor page.
+        /// </summary>
+        /// <param name="page">The razor page.</param>
+        /// <param name="lineNumber">The optional current line number.</param>
+        /// <returns>
+        /// The current line number of the razor page.
+        /// </returns>
+        public static int CurrentLineNumber(this IRazorPage page, [CallerLineNumber] int lineNumber = 0)
+        {
+            return lineNumber;
+        }
+    }
+}

--- a/src/Website/Views/Projects/Index.cshtml
+++ b/src/Website/Views/Projects/Index.cshtml
@@ -120,7 +120,7 @@
             <div class="panel-body">
                 <p>
                     The very website you're looking at
-                    <a id="link-self-source" href="https://github.com/martincostello/website/blob/deploy/src/Website/Views/Projects/Index.cshtml" title="View the source for this page">
+                    <a id="link-self-source" href="https://github.com/martincostello/website/blob/@GitMetadata.Commit/src/Website/Views/Projects/Index.cshtml#L@(this.CurrentLineNumber())" title="View the source for this page">
                         right now
                     </a>
                     which is implemented using ASP.NET Core.


### PR DESCRIPTION
Change the link on ```/projects``` for the page itself to go directly to the line of code for the exact revision in GitHub.