### PR TITLE
Add empty parameters.xml

### DIFF
--- a/src/Website/parameters.xml
+++ b/src/Website/parameters.xml
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<parameters>
+</parameters>

--- a/src/Website/project.json
+++ b/src/Website/project.json
@@ -116,7 +116,7 @@
 
   "publishOptions": {
     "include": [ "wwwroot", "Views" ],
-    "includeFiles": [ "appsettings.json", "bower.json", "project.json", "web.config" ]
+    "includeFiles": [ "appsettings.json", "bower.json", "parameters.xml", "project.json", "web.config" ]
   },
 
   "scripts": {


### PR DESCRIPTION
Add an empty ```parameters.xml``` to keep MSDeploy happy when the website is packaged up.

Relates to #28 and #34.