### PR TITLE
Update to latest npm in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,8 @@ branches:
     - master
 
 install:
+  - ps: npm install npm -g
+  - ps: npm -v
   - ps: npm cache clean --loglevel=error
   - ps: npm install -g bower --loglevel=error
   - ps: npm install -g gulp --loglevel=error


### PR DESCRIPTION
Update to the latest version of npm in AppVeyor builds to try and resolve intermittent npm install errors (npm/npm#9696) that cause the build to fail during ```dotnet publish```.