### PR TITLE
Add site revision to HTML and JS as metadata

### DIFF
--- a/src/Website/Assets/Scripts/js/site.js
+++ b/src/Website/Assets/Scripts/js/site.js
@@ -1,4 +1,6 @@
 ﻿martinCostello = {
     website: {
+        branch: $("meta[name='x-site-branch']").attr("content"),
+        revision: $("meta[name='x-site-revision']").attr("content")
     }
 };

--- a/src/Website/Views/Shared/_Meta.cshtml
+++ b/src/Website/Views/Shared/_Meta.cshtml
@@ -44,3 +44,5 @@
     <meta name="msapplication-starturl" content="/" />
     <meta name="msapplication-TileColor" content="#2d89ef" />
     <meta name="msapplication-TileImage" content="@Url.Content("~/mstile-144x144.png")" asp-append-version="true" />
+    <meta name="x-site-branch" content="@GitMetadata.Branch" />
+    <meta name="x-site-revision" content="@GitMetadata.Commit" />


### PR DESCRIPTION
Add the site's Git revision and branch to the HTML as ```<meta>``` tags and reference them as JavaScript properties (e.g. ```martinCostello.website.revision```).