### PR TITLE
Use 'self' instead of explicit URI for CSP

### DIFF
--- a/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
@@ -148,7 +148,7 @@ frame-ancestors 'none';
 form-action 'self';
 block-all-mixed-content;
 reflected-xss block;
-base-uri https://martincostello.com;
+base-uri 'self';
 manifest-src 'self';";
 
             var builder = new StringBuilder(basePolicy.Replace(Environment.NewLine, string.Empty));


### PR DESCRIPTION
Use ```'self'``` instead of explicitly setting the domain for ```base-uri``` in the Content Security Policy.