### PR TITLE
Fix typo in microdata

### DIFF
--- a/src/Website/Views/Shared/_Meta.cshtml
+++ b/src/Website/Views/Shared/_Meta.cshtml
@@ -91,7 +91,7 @@
         "jobTitle": "Senior Engineer",
         "nationality": "British",
         "sameAs": [
-            "@Options.ExternalLinks.Blog.AbsoluteUri",s
+            "@Options.ExternalLinks.Blog.AbsoluteUri",
             "https://github.com/martincostello",
             "https://keybase.io/martincostello",
             "https://twitter.com/martin_costello"


### PR DESCRIPTION
Fix typo in microdata caused by a rogue ```ctrl+s```.