### PR TITLE
Use fixed dotnet CLI version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 dist: trusty
 
 env:
-  - CLI_VERSION=latest
+  - CLI_VERSION=1.0.0-preview2-003121
 
 branches:
   only:

--- a/Build.ps1
+++ b/Build.ps1
@@ -13,7 +13,7 @@ $ErrorActionPreference = "Stop"
 $solutionPath  = Split-Path $MyInvocation.MyCommand.Definition
 $framework     = "netcoreapp1.0"
 $getDotNet     = Join-Path $solutionPath "tools\install.ps1"
-$dotnetVersion = "latest"
+$dotnetVersion = "1.0.0-preview2-003121"
 
 if ($OutputPath -eq "") {
     $OutputPath = "$(Convert-Path "$PSScriptRoot")\artifacts"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ os: Visual Studio 2015
 version: 1.0.{build}
 
 environment:
-  CLI_VERSION: latest
+  CLI_VERSION: 1.0.0-preview2-003121
 
 branches:
   only:
@@ -11,7 +11,6 @@ branches:
 install:
   - ps: npm install npm -g
   - ps: npm -v
-  - ps: npm cache clean --loglevel=error
   - ps: npm install -g bower --loglevel=error
   - ps: npm install -g gulp --loglevel=error
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ branches:
     - master
 
 install:
-  - ps: npm install npm -g
+  - ps: npm install npm@3.10.6 -g
   - ps: npm -v
   - ps: npm install -g bower --loglevel=error
   - ps: npm install -g gulp --loglevel=error


### PR DESCRIPTION
Use a fixed version of the dotnet CLI (```1.0.0-preview2-003121```) instead of ```latest```, as sometimes this causes build failures.

Also remove the step to clear the npm package cache in AppVeyor.