### PR TITLE
Use absolute URIs for image meta tags

### DIFF
--- a/src/Website/Extensions/IUrlHelperExtensions.cs
+++ b/src/Website/Extensions/IUrlHelperExtensions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Website.Extensions
+{
+    using System;
+    using Microsoft.AspNetCore.Mvc;
+
+    /// <summary>
+    /// A class containing extension methods for the <see cref=""/> class. This class cannot be inherited.
+    /// </summary>
+    public static class IUrlHelperExtensions
+    {
+        /// <summary>
+        /// Converts a virtual (relative) path to an application absolute URI.
+        /// </summary>
+        /// <param name="value">The <see cref="IUrlHelper"/>.</param>
+        /// <param name="contentPath">The virtual path of the content.</param>
+        /// <returns>The application absolute URI.</returns>
+        public static string AbsoluteContent(this IUrlHelper value, string contentPath)
+        {
+            var request = value.ActionContext.HttpContext.Request;
+            return new Uri(new Uri(request.Scheme + "://" + request.Host.Value), value.Content(contentPath)).ToString();
+        }
+    }
+}

--- a/src/Website/Views/Home/About.cshtml
+++ b/src/Website/Views/Home/About.cshtml
@@ -3,8 +3,6 @@
 @{
     ViewBag.Title = "About Martin";
     ViewBag.MetaDescription = "Information about Martin Costello, a software developer and tester.";
-    ViewBag.MetaImage = Url.Content("~/assets/img/Martin_Small.png");
-    ViewBag.MetaImageAltText = "Martin Costello";
     int yearsExperience = (int)Math.Floor((DateTimeOffset.UtcNow - new DateTimeOffset(2006, 9, 4, 0, 0, 0, TimeSpan.Zero)).TotalDays / 365);
 }
 <div class="row">

--- a/src/Website/Views/Shared/_Meta.cshtml
+++ b/src/Website/Views/Shared/_Meta.cshtml
@@ -28,8 +28,8 @@
     }
     else
     {
-    <meta property="og:image" content="@Url.Content("~/assets/img/martin_small.png")" />
-    <meta name="twitter:image" content="@Url.Content("~/assets/img/martin_small.png")" />
+    <meta property="og:image" content="@Url.AbsoluteContent("~/assets/img/martin_small.png")" />
+    <meta name="twitter:image" content="@Url.AbsoluteContent("~/assets/img/martin_small.png")" />
     <meta name="twitter:image:alt" content="@Model.Author" />
     }
     <meta property="og:locale" content="en_GB" />


### PR DESCRIPTION
Use absolute URIs in meta tags for images to resolve #69.

Also remove redundant setting of image meta for ```/home/about```.