### PR TITLE
Add CSP report URI

### DIFF
--- a/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
@@ -153,6 +153,11 @@ manifest-src 'self';";
                 builder.Append("upgrade-insecure-requests;");
             }
 
+            if (options?.ExternalLinks?.Reports?.ContentSecurityPolicy != null)
+            {
+                builder.Append($"report-uri {options.ExternalLinks.Reports.ContentSecurityPolicy};");
+            }
+
             return builder.ToString();
         }
 

--- a/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
@@ -151,11 +151,11 @@ manifest-src 'self';";
             if (isProduction)
             {
                 builder.Append("upgrade-insecure-requests;");
-            }
 
-            if (options?.ExternalLinks?.Reports?.ContentSecurityPolicy != null)
-            {
-                builder.Append($"report-uri {options.ExternalLinks.Reports.ContentSecurityPolicy};");
+                if (options?.ExternalLinks?.Reports?.ContentSecurityPolicy != null)
+                {
+                    builder.Append($"report-uri {options.ExternalLinks.Reports.ContentSecurityPolicy};");
+                }
             }
 
             return builder.ToString();

--- a/src/Website/Options/ExternalLinksOptions.cs
+++ b/src/Website/Options/ExternalLinksOptions.cs
@@ -24,5 +24,10 @@ namespace MartinCostello.Website.Options
         /// Gets or sets the URI of the status website.
         /// </summary>
         public Uri Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets the options for the URIs to use for reports.
+        /// </summary>
+        public ReportOptions Reports { get; set; }
     }
 }

--- a/src/Website/Options/ReportOptions.cs
+++ b/src/Website/Options/ReportOptions.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Website.Options
+{
+    using System;
+
+    /// <summary>
+    /// A class representing the options for reports. This class cannot be inherited.
+    /// </summary>
+    public sealed class ReportOptions
+    {
+        /// <summary>
+        /// Gets or sets the URI to use for <c>Content-Security-Policy</c>.
+        /// </summary>
+        public Uri ContentSecurityPolicy { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URI to use for <c>Content-Security-Policy-Report-Only</c>.
+        /// </summary>
+        public Uri ContentSecurityPolicyReportOnly { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URI to use for <c>Public-Key-Pins</c>.
+        /// </summary>
+        public Uri PublicKeyPins { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URI to use for <c>Public-Key-Pins-Report-Only</c>.
+        /// </summary>
+        public Uri PublicKeyPinsReportOnly { get; set; }
+    }
+}

--- a/src/Website/appsettings.json
+++ b/src/Website/appsettings.json
@@ -14,7 +14,13 @@
     "ExternalLinks": {
       "Api": "https://api.martincostello.com/",
       "Blog": "https://blog.martincostello.com/",
-      "Status": "http://status.martincostello.com/"
+      "Status": "http://status.martincostello.com/",
+      "Reports": {
+        "ContentSecurityPolicy": "https://martincostello.report-uri.io/r/default/csp/enforce",
+        "ContentSecurityPolicyReportOnly": "https://martincostello.report-uri.io/r/default/csp/reportOnly",
+        "PublicKeyPins": "https://martincostello.report-uri.io/r/default/hpkp/enforce",
+        "PublicKeyPinsReportOnly": "https://martincostello.report-uri.io/r/default/hpkp/reportOnly"
+      }
     },
     "Metadata": {
       "Author": {


### PR DESCRIPTION
Add ```report-uri``` to the content security policy in production.

Also configures report URIs for ```Content-Security-Policy-Report-Only```, ```Public-Key-Pins``` and ```Public-Key-Pins-Report-Only```.