### PR TITLE
Fix CSP warnings in Firefox

### DIFF
--- a/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
@@ -141,14 +141,14 @@ namespace MartinCostello.Website.Middleware
         private static string BuildContentSecurityPolicy(bool isProduction, SiteOptions options)
         {
             var basePolicy = $@"
-default-src 'self';
+default-src 'self' maxcdn.bootstrapcdn.com;
 script-src 'self' ajax.googleapis.com cdnjs.cloudflare.com maxcdn.bootstrapcdn.com platform.linkedin.com platform.twitter.com www.google-analytics.com www.openhub.net 'unsafe-inline';
 style-src 'self' ajax.googleapis.com fonts.googleapis.com maxcdn.bootstrapcdn.com 'unsafe-inline';
 img-src 'self' stackoverflow.com static.licdn.com stats.g.doubleclick.net syndication.twitter.com www.google-analytics.com www.linkedin.com www.openhub.net data:;
 font-src 'self' ajax.googleapis.com fonts.googleapis.com fonts.gstatic.com maxcdn.bootstrapcdn.com;
 connect-src 'self' {GetApiOriginForContentSecurityPolicy(options)};
 media-src 'none';
-object-src cdnjs.cloudflare.com;
+object-src ajax.cdnjs.com cdnjs.cloudflare.com;
 child-src ghbtns.com platform.linkedin.com platform.twitter.com www.openhub.net;
 frame-ancestors 'none';
 form-action 'self';


### PR DESCRIPTION
Fix content security policy warnings in Firefox.
  1. ```ajax.cdnjs.com``` is warned for an object source which does not occur in Chrome.
  1. Firefox seems to want ```maxcdn.bootstrapcdn.com``` in ```default-src``` despite Chrome not generating a warning and it being specified for scripts, styles and fonts.

Only became apparent after reviewing reports since #77 was merged.