### PR TITLE
Improve CSS imports

### DIFF
--- a/src/Website/Views/Shared/_Layout.cshtml
+++ b/src/Website/Views/Shared/_Layout.cshtml
@@ -21,11 +21,10 @@
             imageAltText: ViewBag.MetaImageAltText as string,
             robots: ViewBag.MetaRobots as string,
             title: ViewBag.Title as string);
-
-        await Html.RenderPartialAsync("_Meta", model);
-        await Html.RenderPartialAsync("_Links", canonicalUri);
-        await Html.RenderPartialAsync("_Styles");
     }
+    @await Html.PartialAsync("_Meta", model)
+    @await Html.PartialAsync("_Links", canonicalUri)
+    @await Html.PartialAsync("_Styles")
     @await RenderSectionAsync("meta", required: false)
     @await RenderSectionAsync("styles", required: false)
     <script type="text/javascript">

--- a/src/Website/Views/Shared/_Layout.cshtml
+++ b/src/Website/Views/Shared/_Layout.cshtml
@@ -25,8 +25,8 @@
         await Html.RenderPartialAsync("_Meta", model);
         await Html.RenderPartialAsync("_Links", canonicalUri);
     }
-    @RenderSection("meta", required: false)
-    @RenderSection("styles", required: false)
+    @await RenderSectionAsync("meta", required: false)
+    @await RenderSectionAsync("styles", required: false)
     <script type="text/javascript">
         if (self == top) {
             document.documentElement.className = document.documentElement.className.replace(/\bjs-flash\b/, '');
@@ -63,7 +63,7 @@
         @await Html.PartialAsync("_Footer", Options)
     </div>
     @await Html.PartialAsync("_Scripts", BowerVersions)
-    @RenderSection("scripts", required: false)
+    @await RenderSectionAsync("scripts", required: false)
 </body>
 <!--
     Datacenter: @Config["Azure:Datacenter"]

--- a/src/Website/Views/Shared/_Layout.cshtml
+++ b/src/Website/Views/Shared/_Layout.cshtml
@@ -24,7 +24,6 @@
     }
     @await Html.PartialAsync("_Meta", model)
     @await Html.PartialAsync("_Links", canonicalUri)
-    @await Html.PartialAsync("_Styles")
     @await RenderSectionAsync("meta", required: false)
     @await RenderSectionAsync("styles", required: false)
     <script type="text/javascript">
@@ -62,6 +61,7 @@
         @RenderBody()
         @await Html.PartialAsync("_Footer", Options)
     </div>
+    @await Html.PartialAsync("_Styles")
     @await Html.PartialAsync("_Scripts", BowerVersions)
     @await RenderSectionAsync("scripts", required: false)
 </body>

--- a/src/Website/Views/Shared/_Layout.cshtml
+++ b/src/Website/Views/Shared/_Layout.cshtml
@@ -24,6 +24,7 @@
 
         await Html.RenderPartialAsync("_Meta", model);
         await Html.RenderPartialAsync("_Links", canonicalUri);
+        await Html.RenderPartialAsync("_Styles");
     }
     @await RenderSectionAsync("meta", required: false)
     @await RenderSectionAsync("styles", required: false)

--- a/src/Website/Views/Shared/_Links.cshtml
+++ b/src/Website/Views/Shared/_Links.cshtml
@@ -36,7 +36,6 @@
           asp-fallback-test-class="sr-only"
           asp-fallback-test-property="position"
           asp-fallback-test-value="absolute" />
-    <link rel="stylesheet" href="~/assets/css/site.min.css" asp-append-version="true" />
 </environment>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/@BowerVersions["bootstrap"]/flatly/bootstrap.min.css" integrity="sha384-+ENW/yibaokMnme+vBLnHMphUYxHs34h9lpdbSLuAwGkOKFRl4C34WkjazBtb7eT" crossorigin="anonymous" />
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/@BowerVersions["font-awesome"]/css/font-awesome.min.css" integrity="sha256-AIodEDkC8V/bHBkfyxzolUMw57jeQ9CauwhVW6YJ9CA=" crossorigin="anonymous"

--- a/src/Website/Views/Shared/_Links.cshtml
+++ b/src/Website/Views/Shared/_Links.cshtml
@@ -17,9 +17,6 @@
     <link rel="icon" type="image/png" href="@Url.Content("~/favicon-32x32.png")" sizes="32x32" asp-append-version="true" />
     <link rel="icon" type="image/png" href="@Url.Content("~/favicon-96x96.png")" sizes="96x96" asp-append-version="true" />
     <link rel="icon" type="image/png" href="@Url.Content("~/favicon-16x16.png")" sizes="16x16" asp-append-version="true" />
-<environment names="Development">
-    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" asp-append-version="true" />
-</environment>
 <environment names="Staging,Production">
     <link rel="dns-prefetch" href="//ajax.googleapis.com" />
     <link rel="dns-prefetch" href="//fonts.googleapis.com" />
@@ -31,16 +28,4 @@
     <link rel="preconnect" href="//fonts.gstatic.com" />
     <link rel="preconnect" href="//maxcdn.bootstrapcdn.com" />
     <link rel="preconnect" href="//www.google-analytics.com" />
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/@BowerVersions["bootstrap"]/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous"
-          asp-fallback-href="~/lib/bootstrap/dist/css/bootstrap.min.css"
-          asp-fallback-test-class="sr-only"
-          asp-fallback-test-property="position"
-          asp-fallback-test-value="absolute" />
-</environment>
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/@BowerVersions["bootstrap"]/flatly/bootstrap.min.css" integrity="sha384-+ENW/yibaokMnme+vBLnHMphUYxHs34h9lpdbSLuAwGkOKFRl4C34WkjazBtb7eT" crossorigin="anonymous" />
-<environment names="Development">
-    <link rel="stylesheet" href="~/assets/css/site.css" asp-append-version="true" />
-</environment>
-<environment names="Staging,Production">
-    <link rel="stylesheet" href="~/assets/css/site.min.css" asp-append-version="true" />
 </environment>

--- a/src/Website/Views/Shared/_Links.cshtml
+++ b/src/Website/Views/Shared/_Links.cshtml
@@ -38,9 +38,6 @@
           asp-fallback-test-value="absolute" />
 </environment>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/@BowerVersions["bootstrap"]/flatly/bootstrap.min.css" integrity="sha384-+ENW/yibaokMnme+vBLnHMphUYxHs34h9lpdbSLuAwGkOKFRl4C34WkjazBtb7eT" crossorigin="anonymous" />
-    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/@BowerVersions["font-awesome"]/css/font-awesome.min.css" integrity="sha256-AIodEDkC8V/bHBkfyxzolUMw57jeQ9CauwhVW6YJ9CA=" crossorigin="anonymous"
-          asp-fallback-href="~/lib/font-awesome/css/font-awesome.min.css"
-          asp-fallback-test-class="fa" asp-fallback-test-property="display" asp-fallback-test-value="inline-block" />
 <environment names="Development">
     <link rel="stylesheet" href="~/assets/css/site.css" asp-append-version="true" />
 </environment>

--- a/src/Website/Views/Shared/_Styles.cshtml
+++ b/src/Website/Views/Shared/_Styles.cshtml
@@ -1,0 +1,18 @@
+﻿@inject BowerVersions BowerVersions
+<environment names="Development">
+    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" asp-append-version="true" />
+</environment>
+<environment names="Staging,Production">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/@BowerVersions["bootstrap"]/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous"
+          asp-fallback-href="~/lib/bootstrap/dist/css/bootstrap.min.css"
+          asp-fallback-test-class="sr-only"
+          asp-fallback-test-property="position"
+          asp-fallback-test-value="absolute" />
+</environment>
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/@BowerVersions["bootstrap"]/flatly/bootstrap.min.css" integrity="sha384-+ENW/yibaokMnme+vBLnHMphUYxHs34h9lpdbSLuAwGkOKFRl4C34WkjazBtb7eT" crossorigin="anonymous" />
+<environment names="Development">
+    <link rel="stylesheet" href="~/assets/css/site.css" asp-append-version="true" />
+</environment>
+<environment names="Staging,Production">
+    <link rel="stylesheet" href="~/assets/css/site.min.css" asp-append-version="true" />
+</environment>

--- a/src/Website/bower.json
+++ b/src/Website/bower.json
@@ -3,7 +3,6 @@
   "private": true,
   "dependencies": {
     "bootstrap": "3.3.7",
-    "font-awesome": "4.6.3",
     "jquery": "2.2.3",
     "jquery.lazyload": "1.9.1",
     "zeroclipboard": "2.2.0"

--- a/src/Website/wwwroot/error.html
+++ b/src/Website/wwwroot/error.html
@@ -12,7 +12,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1, maximum-scale=1" />
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha256-7s5uDGW3AHqw6xtJmNNtr+OBRJUlgkNJEo78P4b0yRw=" crossorigin="anonymous" />
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.6/flatly/bootstrap.min.css" integrity="sha256-Av2lUNJFz7FqxLquvIFyxyCQA/VHUFna3onVy+5jUBM=" crossorigin="anonymous" />
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" integrity="sha256-AIodEDkC8V/bHBkfyxzolUMw57jeQ9CauwhVW6YJ9CA=" crossorigin="anonymous" />
     <script type="text/javascript">
         if (self == top) {
             document.documentElement.className = document.documentElement.className.replace(/\bjs-flash\b/, '');

--- a/src/Website/wwwroot/error.html
+++ b/src/Website/wwwroot/error.html
@@ -52,7 +52,5 @@
     </script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous">
     </script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.min.js" integrity="sha256-rXnOfjTRp4iAm7hTAxEz3irkXzwZrElV2uRsdJAYjC4=" crossorigin="anonymous">
-    </script>
 </body>
 </html>

--- a/src/Website/wwwroot/error.html
+++ b/src/Website/wwwroot/error.html
@@ -10,8 +10,8 @@
     <meta name="language" content="en" />
     <meta name="robots" content="NOINDEX" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1, maximum-scale=1" />
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha256-7s5uDGW3AHqw6xtJmNNtr+OBRJUlgkNJEo78P4b0yRw=" crossorigin="anonymous" />
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.6/flatly/bootstrap.min.css" integrity="sha256-Av2lUNJFz7FqxLquvIFyxyCQA/VHUFna3onVy+5jUBM=" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/flatly/bootstrap.min.css" integrity="sha384-+ENW/yibaokMnme+vBLnHMphUYxHs34h9lpdbSLuAwGkOKFRl4C34WkjazBtb7eT" crossorigin="anonymous" />
     <script type="text/javascript">
         if (self == top) {
             document.documentElement.className = document.documentElement.className.replace(/\bjs-flash\b/, '');
@@ -50,7 +50,7 @@
     </div>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.3/jquery.min.js" integrity="sha256-a23g1Nt4dtEYOj7bR+vTu7+T8VP13humZFBJNIYoEJo=" crossorigin="anonymous">
     </script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha256-KXn5puMvxCw+dAYznun+drMdG1IFl3agK0p/pqT9KAo=" crossorigin="anonymous">
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous">
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.min.js" integrity="sha256-rXnOfjTRp4iAm7hTAxEz3irkXzwZrElV2uRsdJAYjC4=" crossorigin="anonymous">
     </script>


### PR DESCRIPTION
As part of #15 improve CSS imports by:

  * Fix site CSS being imported twice in production;
  * Remove font-awesome as it isn't used;
  * Update static error page to Bootstrap 3.3.7 (missed from #86);
  * Remove jQuery lazyload from static error page as it isn't used;
  * Render sections asynchronously;
  * Move CSS import to dedicated partial view;
  * Render CSS in ```<body>``` instead of ```<head>```.