### PR TITLE
No-flash clipboard support

### DIFF
--- a/src/Website/Assets/Scripts/js/clipboard.js
+++ b/src/Website/Assets/Scripts/js/clipboard.js
@@ -3,19 +3,11 @@
 
 (function () {
     $(document).ready(function () {
+        if ("Clipboard" in window) {
+            var selector = ".copy-button";
+            var copyButton = $(selector);
 
-        var swfPath = $("link[rel='clipboard-swf']").attr("href");
-
-        if (swfPath) {
-
-            var copyButton = $(".copy-button");
-            var clipboardInitialized = false;
-
-            ZeroClipboard.config({
-                swfPath: swfPath
-            });
-
-            new ZeroClipboard(copyButton);
+            new Clipboard(selector);
 
             copyButton.click(function (event) {
                 event.preventDefault();

--- a/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
@@ -148,7 +148,7 @@ img-src 'self' stackoverflow.com static.licdn.com stats.g.doubleclick.net syndic
 font-src 'self' ajax.googleapis.com fonts.googleapis.com fonts.gstatic.com maxcdn.bootstrapcdn.com;
 connect-src 'self' {GetApiOriginForContentSecurityPolicy(options)};
 media-src 'none';
-object-src ajax.cdnjs.com cdnjs.cloudflare.com;
+object-src ajax.cdnjs.com;
 child-src ghbtns.com platform.linkedin.com platform.twitter.com www.openhub.net;
 frame-ancestors 'none';
 form-action 'self';

--- a/src/Website/Views/Tools/Index.cshtml
+++ b/src/Website/Views/Tools/Index.cshtml
@@ -4,19 +4,18 @@
     ViewBag.Title = ".NET Development Tools";
     ViewBag.MetaDescription = ".NET Development Tools for generating GUIDs, machine keys and hashing text.";
 
-    var clipboardVersion = Bower["zeroclipboard"];
+    var clipboardVersion = Bower["clipboard"];
     var toolsUri = Options.ExternalLinks.Api.AbsoluteUri + "tools";
 }
 @section meta {
    <link rel="api-guid" href="@toolsUri/guid" />
    <link rel="api-hash" href="@toolsUri/hash" />
    <link rel="api-machine-key" href="@toolsUri/machinekey" />
-   <link rel="clipboard-swf" href="https://cdnjs.cloudflare.com/ajax/libs/zeroclipboard/@clipboardVersion/ZeroClipboard.swf" />
 }
 @section scripts {
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/zeroclipboard/@clipboardVersion/ZeroClipboard.min.js" integrity="sha256-Dv7XDh3wH0KTf2EqLETkJME+/v1CTy/u7nDwEkD/zJA=" crossorigin="anonymous"
-            asp-fallback-src="~/lib/zeroclipboard/zeroclipboard.min.js"
-            asp-fallback-test="window.ZeroClipboard">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/@clipboardVersion/clipboard.min.js" integrity="sha256-COWXDc7n7PAqsE3y1r4CVopxWU9JI0kenz6K4zBqhT8=" crossorigin="anonymous"
+            asp-fallback-src="~/lib/clipboard/dist/clipboard.min.js"
+            asp-fallback-test="window.Clipboard">
     </script>
 }
 <h1>@ViewBag.Title</h1>

--- a/src/Website/Views/Tools/_GenerateGuid.cshtml
+++ b/src/Website/Views/Tools/_GenerateGuid.cshtml
@@ -8,7 +8,7 @@
                     @Html.TextBox("text-guid", @Guid.NewGuid().ToString(), new { @class = "form-control code", id = "text-guid", @readonly = string.Empty })
                     <span class="input-group-btn">
                         <button id="copy-guid" class="btn btn-default copy-button" data-clipboard-target="#text-guid" title="Copy to clipboard">
-                            <span class="glyphicon glyphicon-save"></span>
+                            <span class="glyphicon glyphicon-copy"></span>
                         </button>
                     </span>
                 </div>

--- a/src/Website/Views/Tools/_GenerateGuid.cshtml
+++ b/src/Website/Views/Tools/_GenerateGuid.cshtml
@@ -5,9 +5,9 @@
         <div class="form-group">
             <div class="col-md-offset-2 col-md-7">
                 <div class="input-group">
-                    @Html.TextBox("text-guid", @Guid.NewGuid().ToString(), new { @class = "form-control code", id = "text-guid", disabled = string.Empty })
+                    @Html.TextBox("text-guid", @Guid.NewGuid().ToString(), new { @class = "form-control code", id = "text-guid", @readonly = string.Empty })
                     <span class="input-group-btn">
-                        <button id="copy-guid" class="btn btn-default copy-button" data-clipboard-target="text-guid" title="Copy to clipboard">
+                        <button id="copy-guid" class="btn btn-default copy-button" data-clipboard-target="#text-guid" title="Copy to clipboard">
                             <span class="glyphicon glyphicon-save"></span>
                         </button>
                     </span>

--- a/src/Website/Views/Tools/_GenerateHash.cshtml
+++ b/src/Website/Views/Tools/_GenerateHash.cshtml
@@ -41,7 +41,7 @@
                     @Html.TextBox("text-hash", string.Empty, new { @class = "form-control code", id = "text-hash", @readonly = string.Empty })
                     <span class="input-group-btn">
                         <button id="copy-hash" class="btn btn-default copy-button" data-clipboard-target="#text-hash" title="Copy to clipboard">
-                            <span class="glyphicon glyphicon-save"></span>
+                            <span class="glyphicon glyphicon-copy"></span>
                         </button>
                     </span>
                 </div>

--- a/src/Website/Views/Tools/_GenerateHash.cshtml
+++ b/src/Website/Views/Tools/_GenerateHash.cshtml
@@ -38,9 +38,9 @@
             <label for="text-hash" class="control-label col-md-2">Hash</label>
             <div class="col-md-7">
                 <div class="input-group">
-                    @Html.TextBox("text-hash", string.Empty, new { @class = "form-control code", id = "text-hash", disabled = string.Empty })
+                    @Html.TextBox("text-hash", string.Empty, new { @class = "form-control code", id = "text-hash", @readonly = string.Empty })
                     <span class="input-group-btn">
-                        <button id="copy-hash" class="btn btn-default copy-button" data-clipboard-target="text-hash" title="Copy to clipboard">
+                        <button id="copy-hash" class="btn btn-default copy-button" data-clipboard-target="#text-hash" title="Copy to clipboard">
                             <span class="glyphicon glyphicon-save"></span>
                         </button>
                     </span>

--- a/src/Website/Views/Tools/_GenerateMachineKey.cshtml
+++ b/src/Website/Views/Tools/_GenerateMachineKey.cshtml
@@ -43,7 +43,7 @@
             <div id="div-machine-key-copy" class="form-group">
                 <div class="col-md-offset-2 col-md-8">
                     <a id="copy-machine-key" href="#" rel="nofollow" class="btn btn-default copy-button" data-clipboard-target="#machine-key-xml" title="Copy to clipboard">
-                        Copy to clipboard <span class="glyphicon glyphicon-save"></span>
+                        Copy to clipboard <span class="glyphicon glyphicon-copy"></span>
                     </a>
                 </div>
             </div>

--- a/src/Website/Views/Tools/_GenerateMachineKey.cshtml
+++ b/src/Website/Views/Tools/_GenerateMachineKey.cshtml
@@ -42,7 +42,7 @@
             </div>
             <div id="div-machine-key-copy" class="form-group">
                 <div class="col-md-offset-2 col-md-8">
-                    <a id="copy-machine-key" href="#" rel="nofollow" class="btn btn-default copy-button" data-clipboard-target="#machine-key-xml" title="Copy to clipboard">
+                    <a id="copy-machine-key" href="#" rel="nofollow" class="btn btn-primary copy-button" data-clipboard-target="#machine-key-xml" title="Copy to clipboard">
                         Copy to clipboard <span class="glyphicon glyphicon-copy"></span>
                     </a>
                 </div>

--- a/src/Website/Views/Tools/_GenerateMachineKey.cshtml
+++ b/src/Website/Views/Tools/_GenerateMachineKey.cshtml
@@ -42,7 +42,7 @@
             </div>
             <div id="div-machine-key-copy" class="form-group">
                 <div class="col-md-offset-2 col-md-8">
-                    <a id="copy-machine-key" href="#" rel="nofollow" class="btn btn-default copy-button" data-clipboard-target="machine-key-xml" title="Copy to clipboard">
+                    <a id="copy-machine-key" href="#" rel="nofollow" class="btn btn-default copy-button" data-clipboard-target="#machine-key-xml" title="Copy to clipboard">
                         Copy to clipboard <span class="glyphicon glyphicon-save"></span>
                     </a>
                 </div>

--- a/src/Website/bower.json
+++ b/src/Website/bower.json
@@ -3,9 +3,9 @@
   "private": true,
   "dependencies": {
     "bootstrap": "3.3.7",
+    "clipboard": "1.5.15",
     "jquery": "2.2.3",
     "jquery.lazyload": "1.9.1",
-    "moment": "2.15.1",
-    "zeroclipboard": "2.2.0"
+    "moment": "2.15.1"
   }
 }


### PR DESCRIPTION
Use [Clipboard](https://clipboardjs.com/) instead of [ZeroClipboard](http://zeroclipboard.org/) to remove the need to allow the use of Flash.

Also updates the UI to use a copy icon instead of a save icon, and fixes an incorrect button style being used for the copy button for machine keys.