### PR TITLE
Remove Mono from Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,6 @@ addons:
     - libssl-dev
     - libunwind8
 
-mono:
-  - latest
-
 install:
   - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
   - curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-language: csharp
-
 sudo: required
 dist: trusty
 


### PR DESCRIPTION
Improve the speed of Travis CI builds by not installing Mono.
Resolves #76.