### PR TITLE
Update GitHub badges

### DIFF
--- a/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
@@ -142,14 +142,14 @@ namespace MartinCostello.Website.Middleware
         {
             var basePolicy = $@"
 default-src 'self' maxcdn.bootstrapcdn.com;
-script-src 'self' ajax.googleapis.com cdnjs.cloudflare.com maxcdn.bootstrapcdn.com platform.linkedin.com platform.twitter.com www.google-analytics.com www.openhub.net 'unsafe-inline';
-style-src 'self' ajax.googleapis.com fonts.googleapis.com maxcdn.bootstrapcdn.com 'unsafe-inline';
-img-src 'self' stackoverflow.com static.licdn.com stats.g.doubleclick.net syndication.twitter.com www.google-analytics.com www.linkedin.com www.openhub.net data:;
+script-src 'self' ajax.googleapis.com api.github.com cdnjs.cloudflare.com buttons.github.io maxcdn.bootstrapcdn.com platform.linkedin.com platform.twitter.com www.google-analytics.com 'unsafe-inline';
+style-src 'self' ajax.googleapis.com buttons.github.io fonts.googleapis.com maxcdn.bootstrapcdn.com 'unsafe-inline';
+img-src 'self' stackoverflow.com static.licdn.com stats.g.doubleclick.net syndication.twitter.com www.google-analytics.com www.linkedin.com data:;
 font-src 'self' ajax.googleapis.com fonts.googleapis.com fonts.gstatic.com maxcdn.bootstrapcdn.com;
 connect-src 'self' {GetApiOriginForContentSecurityPolicy(options)};
 media-src 'none';
 object-src ajax.cdnjs.com;
-child-src ghbtns.com platform.linkedin.com platform.twitter.com www.openhub.net;
+child-src buttons.github.io platform.linkedin.com platform.twitter.com;
 frame-ancestors 'none';
 form-action 'self';
 block-all-mixed-content;

--- a/src/Website/Views/Home/About.cshtml
+++ b/src/Website/Views/Home/About.cshtml
@@ -36,6 +36,10 @@
 <hr />
 <div class="row">
     <div class="col-md-3">
+        <h4>GitHub</h4>
+        <a href="https://github.com/martincostello" class="github-button" target="_blank" data-style="mega" data-count-href="/martincostello/followers" data-count-api="/users/martincostello#followers" data-count-aria-label="# followers on GitHub" aria-label="Follow @@martincostello on GitHub">Follow @@martincostello</a>
+    </div>
+    <div class="col-md-3">
         <h4>LinkedIn</h4>
         <noscript>
             <a href="https://www.linkedin.com/pub/martin-costello/37/253/16a" title="View Martin's LinkedIn profile">@Options.Metadata.Author.Name on LinkedIn</a>
@@ -52,14 +56,9 @@
             <img src="https://stackoverflow.com/users/flair/1064169.png?theme=clean" width="208" height="58" alt="View the profile for martin_costello on Stack Overflow" title="View the profile for martin_costello on Stack Overflow">
         </a>
     </div>
-    <div class="col-md-3">
-        <h4>Open Hub</h4>
-        <a href="https://www.openhub.net/accounts/524611?ref=Detailed" target="_blank">
-            <img alt="Open Hub profile for @Options.Metadata.Author.Name" title="Open Hub profile for @Options.Metadata.Author.Name" border="0" height="35" width="230" src="https://www.openhub.net/accounts/524611/widgets/account_detailed.gif" />
-        </a>
-    </div>
 </div>
 @section scripts {
-    <script async src="//platform.linkedin.com/in.js"></script>
-    <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+    <script async defer src="https://buttons.github.io/buttons.js"></script>
+    <script async defer src="//platform.linkedin.com/in.js"></script>
+    <script async defer src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
 }

--- a/src/Website/Views/Projects/Index.cshtml
+++ b/src/Website/Views/Projects/Index.cshtml
@@ -16,8 +16,8 @@
                     </a>.
                 </p>
                 <p>
-                    <iframe src="https://ghbtns.com/github-btn.html?user=martincostello&repo=sqllocaldb&type=star&count=true" frameborder="0" scrolling="no" width="170" height="20"></iframe>
-                    <iframe src="https://ghbtns.com/github-btn.html?user=martincostello&repo=sqllocaldb&type=fork&count=true" frameborder="0" scrolling="no" width="170" height="20"></iframe>
+                    @await Html.PartialAsync("_GitHubStar", "sqllocaldb")
+                    @await Html.PartialAsync("_GitHubFork", "sqllocaldb")
                 </p>
                 <p>
                     <a id="link-repo-localdb" href="https://github.com/martincostello/sqllocaldb" target="_blank" title="View the project on GitHub" class="btn btn-default">
@@ -39,8 +39,8 @@
                     REST API.
                 </p>
                 <p>
-                    <iframe src="https://ghbtns.com/github-btn.html?user=martincostello&repo=browserstack-automate&type=star&count=true" frameborder="0" scrolling="no" width="170" height="20"></iframe>
-                    <iframe src="https://ghbtns.com/github-btn.html?user=martincostello&repo=browserstack-automate&type=fork&count=true" frameborder="0" scrolling="no" width="170" height="20"></iframe>
+                    @await Html.PartialAsync("_GitHubStar", "browserstack-automate")
+                    @await Html.PartialAsync("_GitHubFork", "browserstack-automate")
                 </p>
                 <p>
                     <a id="link-repo-browserstack" href="https://martincostello.github.io/browserstack-automate/" target="_blank" title="View the project on GitHub" class="btn btn-default">
@@ -62,8 +62,8 @@
                     written as a console application.
                 </p>
                 <p>
-                    <iframe src="https://ghbtns.com/github-btn.html?user=martincostello&repo=project-euler&type=star&count=true" frameborder="0" scrolling="no" width="170" height="20"></iframe>
-                    <iframe src="https://ghbtns.com/github-btn.html?user=martincostello&repo=project-euler&type=fork&count=true" frameborder="0" scrolling="no" width="170" height="20"></iframe>
+                    @await Html.PartialAsync("_GitHubStar", "project-euler")
+                    @await Html.PartialAsync("_GitHubFork", "project-euler")
                 </p>
                 <p>
                     <a id="link-repo-euler" href="https://github.com/martincostello/project-euler" target="_blank" title="View the project on GitHub" class="btn btn-default">
@@ -83,8 +83,8 @@
                     a static site implemented using <a href="https://middlemanapp.com/" title="View the Middleman website" target="_blank">Middleman</a>.
                 </p>
                 <p>
-                    <iframe src="https://ghbtns.com/github-btn.html?user=martincostello&repo=blog&type=star&count=true" frameborder="0" scrolling="no" width="170" height="20"></iframe>
-                    <iframe src="https://ghbtns.com/github-btn.html?user=martincostello&repo=blog&type=fork&count=true" frameborder="0" scrolling="no" width="170" height="20"></iframe>
+                    @await Html.PartialAsync("_GitHubStar", "blog")
+                    @await Html.PartialAsync("_GitHubFork", "blog")
                 </p>
                 <p>
                     <a id="link-repo-blog" href="https://github.com/martincostello/blog" target="_blank" title="View the project on GitHub" class="btn btn-default">
@@ -103,8 +103,8 @@
                     used as an excercise in implementing an ASP.NET Core website.
                 </p>
                 <p>
-                    <iframe src="https://ghbtns.com/github-btn.html?user=martincostello&repo=api&type=star&count=true" frameborder="0" scrolling="no" width="170" height="20"></iframe>
-                    <iframe src="https://ghbtns.com/github-btn.html?user=martincostello&repo=api&type=fork&count=true" frameborder="0" scrolling="no" width="170" height="20"></iframe>
+                    @await Html.PartialAsync("_GitHubStar", "api")
+                    @await Html.PartialAsync("_GitHubFork", "api")
                 </p>
                 <p>
                     <a id="link-repo-api" href="https://github.com/martincostello/api" target="_blank" title="View the project on GitHub" class="btn btn-default">
@@ -126,8 +126,8 @@
                     which is implemented using ASP.NET Core.
                 </p>
                 <p>
-                    <iframe src="https://ghbtns.com/github-btn.html?user=martincostello&repo=website&type=star&count=true" frameborder="0" scrolling="no" width="170" height="20"></iframe>
-                    <iframe src="https://ghbtns.com/github-btn.html?user=martincostello&repo=website&type=fork&count=true" frameborder="0" scrolling="no" width="170" height="20"></iframe>
+                    @await Html.PartialAsync("_GitHubStar", "website")
+                    @await Html.PartialAsync("_GitHubFork", "website")
                 </p>
                 <p>
                     <a id="link-repo-website" href="https://github.com/martincostello/website" target="_blank" title="View the project on GitHub" class="btn btn-default">
@@ -138,3 +138,6 @@
         </div>
     </div>
 </div>
+@section scripts {
+    <script async defer src="https://buttons.github.io/buttons.js"></script>
+}

--- a/src/Website/Views/Projects/_GitHubFork.cshtml
+++ b/src/Website/Views/Projects/_GitHubFork.cshtml
@@ -1,0 +1,5 @@
+﻿@model string
+@{
+    var user = "martincostello";
+}
+<a class="github-button" href="https://github.com/@user/@Model/fork" data-icon="octicon-repo-forked" data-style="mega" data-count-href="/@user/@Model/network" data-count-api="/repos/@user/@Model#forks_count" data-count-aria-label="# forks on GitHub" aria-label="Fork @user/@Model on GitHub">Fork</a>

--- a/src/Website/Views/Projects/_GitHubStar.cshtml
+++ b/src/Website/Views/Projects/_GitHubStar.cshtml
@@ -1,0 +1,5 @@
+﻿@model string
+@{
+    var user = "martincostello";
+}
+<a class="github-button" href="https://github.com/@user/@Model" data-icon="octicon-star" data-style="mega" data-count-href="/@user/@Model/stargazers" data-count-api="/repos/@user/@Model#stargazers_count" data-count-aria-label="# stargazers on GitHub" aria-label="Star @user/@Model on GitHub">Star</a>

--- a/src/Website/Views/Tools/Index.cshtml
+++ b/src/Website/Views/Tools/Index.cshtml
@@ -22,6 +22,9 @@
 <div class="panel panel-default">
     <div class="panel-body">This page contains tools and links to common development tools.</div>
 </div>
+<noscript>
+    <div class="alert alert-warning" role="alert">JavaScript must be enabled in your browser to use these tools.</div>
+</noscript>
 <div>
     @await Html.PartialAsync("_GenerateGuid")
 </div>


### PR DESCRIPTION
  * Update the style of GitHub badges used.
  * Replace the OpenHub badge on the ```/home/about``` page with a GitHub badge.
  * Add a warning alert panel to the ```/tools``` page if JavaScript is disabled in the browser.