### PR TITLE
Use URL rewrite middleware

### DIFF
--- a/src/Website/.vscode/launch.json
+++ b/src/Website/.vscode/launch.json
@@ -15,10 +15,10 @@
       "stopAtEntry": false,
       "launchBrowser": {
         "enabled": true,
-        "args": "http://127.0.0.1:5000/",
+        "args": "http://localhost:5000/",
         "windows": {
           "command": "cmd.exe",
-          "args": "/C start http://127.0.0.1:5000/"
+          "args": "/C start http://localhost:5000/"
         },
         "osx": {
           "command": "open"

--- a/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
@@ -91,7 +91,7 @@ namespace MartinCostello.Website.Middleware
                     context.Response.Headers.Add("X-Frame-Options", "DENY");
                     context.Response.Headers.Add("X-XSS-Protection", "1; mode=block");
 
-                    if (context.Request.IsHttps)
+                    if (context.Request.IsHttps && _isProduction)
                     {
                         context.Response.Headers.Add("Strict-Transport-Security", "max-age=31536000");
 

--- a/src/Website/Properties/launchSettings.json
+++ b/src/Website/Properties/launchSettings.json
@@ -20,7 +20,7 @@
     "Kestrel": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "http://127.0.0.1:5000/",
+      "launchUrl": "http://localhost:5000/",
       "environmentVariables": {
         "Azure:Datacenter": "Local",
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/Website/Startup.cs
+++ b/src/Website/Startup.cs
@@ -214,18 +214,9 @@ namespace MartinCostello.Website
         {
             var options = new RewriteOptions();
 
-            if (HostingEnvironment.IsDevelopment())
-            {
-                options.AddRedirectToHttps(301, 44309);
-            }
-            else
-            {
-                options.AddRedirectToHttps();
-            }
-
             if (HostingEnvironment.IsProduction())
             {
-                // TODO
+                options.AddRedirectToHttps();
             }
 
             return options;

--- a/src/Website/Startup.cs
+++ b/src/Website/Startup.cs
@@ -11,6 +11,7 @@ namespace MartinCostello.Website
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.HttpOverrides;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Rewrite;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
@@ -110,6 +111,7 @@ namespace MartinCostello.Website
                 });
 
             app.UseCookiePolicy(CreateCookiePolicy());
+            app.UseRewriter(CreateRewriteOptions());
         }
 
         /// <summary>
@@ -199,6 +201,24 @@ namespace MartinCostello.Website
                 HttpOnly = HttpOnlyPolicy.Always,
                 Secure = HostingEnvironment.IsDevelopment() ? CookieSecurePolicy.SameAsRequest : CookieSecurePolicy.Always,
             };
+        }
+
+        /// <summary>
+        /// Creates the <see cref="RewriteOptions"/> to use.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="RewriteOptions"/> to use for the application.
+        /// </returns>
+        private RewriteOptions CreateRewriteOptions()
+        {
+            var options = new RewriteOptions();
+
+            if (HostingEnvironment.IsProduction())
+            {
+                // TODO
+            }
+
+            return options;
         }
     }
 }

--- a/src/Website/Startup.cs
+++ b/src/Website/Startup.cs
@@ -102,6 +102,8 @@ namespace MartinCostello.Website
 
             app.UseHttpMethodOverride();
 
+            app.UseRewriter(CreateRewriteOptions());
+
             app.UseMvc(
                 (routes) =>
                 {
@@ -111,7 +113,6 @@ namespace MartinCostello.Website
                 });
 
             app.UseCookiePolicy(CreateCookiePolicy());
-            app.UseRewriter(CreateRewriteOptions());
         }
 
         /// <summary>
@@ -212,6 +213,15 @@ namespace MartinCostello.Website
         private RewriteOptions CreateRewriteOptions()
         {
             var options = new RewriteOptions();
+
+            if (HostingEnvironment.IsDevelopment())
+            {
+                options.AddRedirectToHttps(301, 44309);
+            }
+            else
+            {
+                options.AddRedirectToHttps();
+            }
 
             if (HostingEnvironment.IsProduction())
             {

--- a/src/Website/project.json
+++ b/src/Website/project.json
@@ -51,6 +51,7 @@
     },
     "Microsoft.AspNetCore.ResponseCaching": "1.1.0",
     "Microsoft.AspNetCore.ResponseCompression": "1.0.0",
+    "Microsoft.AspNetCore.Rewrite": "1.0.0",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.1.0",
     "Microsoft.AspNetCore.Server.Kestrel": "1.1.0",
     "Microsoft.AspNetCore.StaticFiles": "1.1.0",


### PR DESCRIPTION
Changes for #103:

  * Add URL rewrite middleware for HTTP-to-HTTPS redirects.
  * Do not return security-related response headers (e.g. for HSTS) when running in development on ```localhost```.
  * Use ```localhost``` instead of ```127.0.0.1``` when running under Kestrel.

Still needs the ```www``` redirect rule adding to the ```RewriteOptions``` and removing it from ```Web.config``` before complete.