### PR TITLE
Service worker fixes

### DIFF
--- a/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
@@ -146,7 +146,7 @@ script-src 'self' ajax.googleapis.com api.github.com cdnjs.cloudflare.com button
 style-src 'self' ajax.googleapis.com buttons.github.io fonts.googleapis.com maxcdn.bootstrapcdn.com 'unsafe-inline';
 img-src 'self' stackoverflow.com static.licdn.com stats.g.doubleclick.net syndication.twitter.com www.google-analytics.com www.linkedin.com data:;
 font-src 'self' ajax.googleapis.com fonts.googleapis.com fonts.gstatic.com maxcdn.bootstrapcdn.com;
-connect-src 'self' {GetApiOriginForContentSecurityPolicy(options)} ajax.googleapis.com cdnjs.cloudflare.com fonts.googleapis.com fonts.gstatic.com maxcdn.bootstrapcdn.com stats.g.doubleclick.net www.google-analytics.com;
+connect-src 'self' {GetApiOriginForContentSecurityPolicy(options)};
 media-src 'none';
 object-src ajax.cdnjs.com;
 child-src 'self' buttons.github.io platform.linkedin.com platform.twitter.com;

--- a/src/Website/wwwroot/service-worker.js
+++ b/src/Website/wwwroot/service-worker.js
@@ -11,7 +11,9 @@ self.addEventListener("install", function (event) {
             return cache.addAll([
                 "/",
                 "/assets/css/site.css",
+                "/assets/css/site.min.css",
                 "/assets/js/site.js",
+                "/assets/js/site.min.js",
                 "/assets/img/browserstack.svg"
             ]);
         })

--- a/src/Website/wwwroot/service-worker.js
+++ b/src/Website/wwwroot/service-worker.js
@@ -28,6 +28,9 @@ self.addEventListener("activate", function (event) {
 });
 
 self.addEventListener("fetch", function (event) {
+    if (event.request.method !== "GET") {
+        return;
+    }
     event.respondWith(
         caches.match(event.request)
             .then(function (response) {

--- a/src/Website/wwwroot/service-worker.js
+++ b/src/Website/wwwroot/service-worker.js
@@ -27,6 +27,7 @@ self.addEventListener("activate", function (event) {
     console.log("Activated Service Worker.");
 });
 
+/*
 self.addEventListener("fetch", function (event) {
     if (event.request.method !== "GET") {
         return;
@@ -38,3 +39,4 @@ self.addEventListener("fetch", function (event) {
             })
     );
 });
+*/

--- a/src/Website/wwwroot/service-worker.js
+++ b/src/Website/wwwroot/service-worker.js
@@ -16,6 +16,8 @@ self.addEventListener("install", function (event) {
                 "/assets/js/site.min.js",
                 "/assets/img/browserstack.svg"
             ]);
+        }).then(function () {
+            return self.skipWaiting();
         })
     );
     console.log("Installed Service Worker.");


### PR DESCRIPTION
Introducing offline caching in the Service Worker has created various issues with the Content Security Policy preventing it from fetching resources due to ```connect-src``` in the CSP lacking various origins (e.g. for social media buttons on ```/home/about```.

Until I can determine a more elegant way to have both, disable the ```fetch``` handler of the Service Worker.

Also some minor improvements to the cached items and how the (commented-out) ```fetch``` handler works.