### PR TITLE
Refactor Content Security Policy

### DIFF
--- a/src/Website/Options/SiteOptions.cs
+++ b/src/Website/Options/SiteOptions.cs
@@ -3,6 +3,8 @@
 
 namespace MartinCostello.Website.Options
 {
+    using System.Collections.Generic;
+
     /// <summary>
     /// A class representing the site configuration. This class cannot be inherited.
     /// </summary>
@@ -12,6 +14,11 @@ namespace MartinCostello.Website.Options
         /// Gets or sets the analytics options for the site.
         /// </summary>
         public AnalyticsOptions Analytics { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Content Security Policy origins for the site.
+        /// </summary>
+        public IDictionary<string, IList<string>> ContentSecurityPolicyOrigins { get; set; }
 
         /// <summary>
         /// Gets or setsht the external link options for the site.

--- a/src/Website/appsettings.json
+++ b/src/Website/appsettings.json
@@ -11,6 +11,16 @@
     "Analytics": {
       "Google": "UA-42907618-1"
     },
+    "ContentSecurityPolicyOrigins": {
+        "child-src": [ "buttons.github.io", "platform.linkedin.com", "platform.twitter.com" ],
+        "connect-src": [],
+        "default-src": [ "buttons.github.io", "maxcdn.bootstrapcdn.com", "platform.linkedin.com", "platform.twitter.com" ],
+        "font-src": [ "ajax.googleapis.com", "fonts.googleapis.com", "fonts.gstatic.com", "maxcdn.bootstrapcdn.com" ],
+        "img-src": [ "stackoverflow.com", "static.licdn.com", "stats.g.doubleclick.net", "syndication.twitter.com", "www.google-analytics.com", "www.linkedin.com" ],
+        "object-src": [ "ajax.cdnjs.com" ],
+        "script-src": [ "ajax.googleapis.com", "api.github.com cdnjs.cloudflare.com", "buttons.github.io", "maxcdn.bootstrapcdn.com", "platform.linkedin.com", "platform.twitter.com", "www.google-analytics.com" ],
+        "style-src": [ "ajax.googleapis.com", "buttons.github.io", "fonts.googleapis.com", "maxcdn.bootstrapcdn.com" ]
+    },
     "ExternalLinks": {
       "Api": "https://api.martincostello.com/",
       "Blog": "https://blog.martincostello.com/",


### PR DESCRIPTION
Refactor the definition of the Content Security policy so that only the keys to use and "special" origins are defined in code.

Other origins are now read from ```appsettings.json```.

Relates to #113.