### PR TITLE
Fix 404 error in service worker

### DIFF
--- a/src/Website/wwwroot/service-worker.js
+++ b/src/Website/wwwroot/service-worker.js
@@ -13,8 +13,7 @@ self.addEventListener("install", function (event) {
                 "/assets/css/site.css",
                 "/assets/css/site.min.css",
                 "/assets/js/site.js",
-                "/assets/js/site.min.js",
-                "/assets/img/browserstack.svg"
+                "/assets/js/site.min.js"
             ]);
         }).then(function () {
             return self.skipWaiting();


### PR DESCRIPTION
Fix HTTP 404 error caused by the service worker trying to cache the BrowserStack image that was deleted by #121.