### PR TITLE
Optimize CSS and improve mobile UX

### DIFF
--- a/src/Website/TagHelpers/InlineStyleTagHelper.cs
+++ b/src/Website/TagHelpers/InlineStyleTagHelper.cs
@@ -1,0 +1,167 @@
+﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Website.TagHelpers
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using System.Text.Encodings.Web;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.Mvc.Routing;
+    using Microsoft.AspNetCore.Mvc.TagHelpers;
+    using Microsoft.AspNetCore.Razor.TagHelpers;
+    using Microsoft.Extensions.Caching.Memory;
+    using Microsoft.Extensions.FileProviders;
+
+    /// <summary>
+    /// A <see cref="ITagHelper"/> implementation targeting &lt;link&gt;
+    /// elements that supports inlining styles for local CSS files.
+    /// </summary>
+    [HtmlTargetElement("link", Attributes = InlineAttributeName, TagStructure = TagStructure.WithoutEndTag)]
+    [HtmlTargetElement("link", Attributes = MinifyInlinedAttributeName, TagStructure = TagStructure.WithoutEndTag)]
+    public class InlineStyleTagHelper : LinkTagHelper
+    {
+        /// <summary>
+        /// The name of the <c>asp-inline</c> attribute.
+        /// </summary>
+        private const string InlineAttributeName = "asp-inline";
+
+        /// <summary>
+        /// The name of the <c>asp-inline</c> attribute.
+        /// </summary>
+        private const string MinifyInlinedAttributeName = "asp-minify-inlined";
+
+        /// <summary>
+        /// An array containing the <c>~</c> character.
+        /// </summary>
+        private static readonly char[] Tilde = new[] { '~' };
+
+        public InlineStyleTagHelper(IHostingEnvironment hostingEnvironment, IMemoryCache cache, HtmlEncoder htmlEncoder, JavaScriptEncoder javaScriptEncoder, IUrlHelperFactory urlHelperFactory)
+            : base(hostingEnvironment, cache, htmlEncoder, javaScriptEncoder, urlHelperFactory)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether CSS should be inlined.
+        /// </summary>
+        [HtmlAttributeName(InlineAttributeName)]
+        public bool? Inline { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether inlined CSS should be minified.
+        /// </summary>
+        [HtmlAttributeName(MinifyInlinedAttributeName)]
+        public bool? MinifyInlined { get; set; }
+
+        /// <inheritdoc />
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (output == null)
+            {
+                throw new ArgumentNullException(nameof(output));
+            }
+
+            bool shouldProcess =
+                Inline == true &&
+                string.Equals(context.AllAttributes["rel"]?.Value?.ToString() as string, "stylesheet", StringComparison.OrdinalIgnoreCase);
+
+            if (!shouldProcess)
+            {
+                // Not enabled or not a stylesheet
+                await base.ProcessAsync(context, output);
+                return;
+            }
+
+            string filePath = (context.AllAttributes["href"].Value as string)?.TrimStart(Tilde);
+            IFileInfo fileInfo = HostingEnvironment.WebRootFileProvider.GetFileInfo(filePath);
+
+            if (!fileInfo.Exists)
+            {
+                // Not a local file
+                await base.ProcessAsync(context, output);
+                return;
+            }
+
+            string css;
+            string cacheKey = $"inline-css-{fileInfo.PhysicalPath}-{MinifyInlined == true}";
+
+            if (!Cache.TryGetValue(cacheKey, out css))
+            {
+                using (var stream = File.OpenRead(fileInfo.PhysicalPath))
+                {
+                    using (var reader = new StreamReader(stream))
+                    {
+                        css = await reader.ReadToEndAsync();
+                    }
+                }
+
+                if (MinifyInlined == true)
+                {
+                    css = MinifyCss(css);
+                }
+
+                Cache.Set(cacheKey, css);
+            }
+
+            output.Content.SetHtmlContent(css);
+
+            output.Attributes.Clear();
+
+            output.TagName = "style";
+            output.TagMode = TagMode.StartTagAndEndTag;
+        }
+
+        /// <summary>
+        /// Naively minify the CSS in the specified string.
+        /// </summary>
+        /// <param name="css">A string containing CSS to minfiy.</param>
+        /// <returns>
+        /// A string containing the minified representation of <paramref name="css"/>.
+        /// </returns>
+        private static string MinifyCss(string css)
+        {
+            // Remove all blank lines, trim space between line contents and turn into a single line
+            string[] lines = css.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            string minified = string.Join(string.Empty, lines.Select((p) => p.Trim()));
+
+            var builder = new StringBuilder(minified);
+
+            for (int i = 0; i < builder.Length - 1; i++)
+            {
+                char ch = builder[i];
+
+                // Remove spaces before element starts, such as: "body {...}" => "body{...}"
+                // Remove spaces after delimited lists, such as: "font: a, b, 'c d'" => "font: a,b,'c d'"
+                // Remove spaces after value starts, such as: "resize: none;" => "resize:none;"
+                if (ch == '{')
+                {
+                    int previous = i - 1;
+
+                    if (builder[previous] == ' ')
+                    {
+                        builder.Remove(previous, 1);
+                    }
+                }
+                else if (ch == ',' || ch == ':')
+                {
+                    int next = i + 1;
+
+                    if (builder[next] == ' ')
+                    {
+                        builder.Remove(next, 1);
+                    }
+                }
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/Website/TagHelpers/InlineStyleTagHelper.cs
+++ b/src/Website/TagHelpers/InlineStyleTagHelper.cs
@@ -35,6 +35,11 @@ namespace MartinCostello.Website.TagHelpers
         private const string MinifyInlinedAttributeName = "asp-minify-inlined";
 
         /// <summary>
+        /// An array containing the <see cref="Environment.NewLine"/> string.
+        /// </summary>
+        private static readonly string[] NewLine = new[] { Environment.NewLine };
+
+        /// <summary>
         /// An array containing the <c>~</c> character.
         /// </summary>
         private static readonly char[] Tilde = new[] { '~' };
@@ -129,7 +134,7 @@ namespace MartinCostello.Website.TagHelpers
         private static string MinifyCss(string css)
         {
             // Remove all blank lines, trim space between line contents and turn into a single line
-            string[] lines = css.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            string[] lines = css.Split(NewLine, StringSplitOptions.RemoveEmptyEntries);
             string minified = string.Join(string.Empty, lines.Select((p) => p.Trim()));
 
             var builder = new StringBuilder(minified);

--- a/src/Website/Views/Home/About.cshtml
+++ b/src/Website/Views/Home/About.cshtml
@@ -23,13 +23,13 @@
             <li>ASP.NET</li>
             <li>Amazon Web Services</li>
             <li>EntityFramework</li>
-            <li>Git</li>
+            <li>Git/GitHub</li>
+            <li>HTML</li>
+            <li>JavaScript</li>
             <li>Microsoft Azure</li>
-            <li>MSBuild</li>
-            <li>MSTest/NUnit/xunit</li>
+            <li>MSTest/xunit</li>
             <li>SQL Server</li>
-            <li>Visual Studio Team Services/Team Foundation Server</li>
-            <li>WCF</li>
+            <li>VSTS/TFS</li>
         </ul>
     </div>
 </div>

--- a/src/Website/Views/Home/About.cshtml
+++ b/src/Website/Views/Home/About.cshtml
@@ -35,24 +35,25 @@
 </div>
 <hr />
 <div class="row">
-    <div class="col-md-3">
-        <h4>GitHub</h4>
-        <a href="https://github.com/martincostello" class="github-button" rel="noopener" target="_blank" data-style="mega" data-count-href="/martincostello/followers" data-count-api="/users/martincostello#followers" data-count-aria-label="# followers on GitHub" aria-label="Follow @@martincostello on GitHub">Follow @@martincostello</a>
+    <div class="col-md-3 col-sm-12 col-xs-12">
+        <h4 class="hidden-xs hidden-sm">GitHub</h4>
+        <a class="github-button hidden-xs hidden-sm" href="https://github.com/martincostello" rel="noopener" target="_blank" data-style="mega" data-count-href="/martincostello/followers" data-count-api="/users/martincostello#followers" data-count-aria-label="# followers on GitHub" aria-label="Follow @@martincostello on GitHub">Follow @@martincostello</a>
     </div>
-    <div class="col-md-3">
+    <div class="col-md-3 hidden-xs hidden-sm">
         <h4>LinkedIn</h4>
         <noscript>
             <a href="https://www.linkedin.com/pub/martin-costello/37/253/16a" title="View Martin's LinkedIn profile">@Options.Metadata.Author.Name on LinkedIn</a>
         </noscript>
-        <script async type="IN/MemberProfile" data-id="https://www.linkedin.com/pub/martin-costello/37/253/16a" data-format="hover" data-text="@Options.Metadata.Author.Name" data-related="false"></script>
+        <script async type="IN/MemberProfile" data-id="https://www.linkedin.com/pub/martin-costello/37/253/16a" data-format="hover" data-text="@Options.Metadata.Author.Name" data-related="false">
+        </script>
     </div>
-    <div class="col-md-3">
-        <h4>Twitter</h4>
-        <a href="https://twitter.com/@Options.Metadata.Author.SocialMedia.Twitter" class="twitter-follow-button" data-size="large" data-show-count="false" title="@Options.Metadata.Author.SocialMedia.Twitter on Twitter">Follow @Options.Metadata.Author.SocialMedia.Twitter</a>
+    <div class="col-md-3 col-sm-12 col-xs-12">
+        <h4 class="hidden-xs hidden-sm">Twitter</h4>
+        <a class="twitter-follow-button" href="https://twitter.com/@Options.Metadata.Author.SocialMedia.Twitter" data-size="large" data-show-count="false" title="@Options.Metadata.Author.SocialMedia.Twitter on Twitter">Follow @Options.Metadata.Author.SocialMedia.Twitter</a>
     </div>
-    <div class="col-md-3">
+    <div class="col-md-3 hidden-xs hidden-sm">
         <h4>Stack Overflow</h4>
-        <a href="https://stackoverflow.com/story/martincostello">
+        <a class="hidden-xs hidden-sm" href="https://stackoverflow.com/story/martincostello">
             <img src="https://stackoverflow.com/users/flair/1064169.png?theme=clean" width="208" height="58" alt="View Martin's Stack Overflow developer story" title="View Martin's Stack Overflow developer story">
         </a>
     </div>

--- a/src/Website/Views/Home/About.cshtml
+++ b/src/Website/Views/Home/About.cshtml
@@ -60,6 +60,6 @@
 </div>
 @section scripts {
     <script async defer src="https://buttons.github.io/buttons.js"></script>
-    <script async defer src="//platform.linkedin.com/in.js"></script>
-    <script async defer src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+    <script async defer src="https://platform.linkedin.com/in.js"></script>
+    <script async defer src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 }

--- a/src/Website/Views/Projects/Index.cshtml
+++ b/src/Website/Views/Projects/Index.cshtml
@@ -137,6 +137,63 @@
             </div>
         </div>
     </div>
+    <div class="col-md-4">
+        <div class="panel panel-default">
+            <div class="panel-heading">Alexa London Travel</div>
+            <div class="panel-body">
+                <p>
+                    An Alexa skill that uses the <a id="link-tfl-api" href="https://api.tfl.gov.uk/" rel="noopener" target="_blank" title="View the TfL API">TfL API</a> to find disruption on London public transport.
+                </p>
+                <p>
+                    @await Html.PartialAsync("_GitHubStar", "alexa-london-travel")
+                    @await Html.PartialAsync("_GitHubFork", "alexa-london-travel")
+                </p>
+                <p>
+                    <a id="link-repo-alexa" href="https://github.com/martincostello/alexa-london-travel" rel="noopener" target="_blank" title="View the project on GitHub" class="btn btn-default">
+                        Visit project site &raquo;
+                    </a>
+                </p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="panel panel-default">
+            <div class="panel-heading">Apple Pay JS Sample Code</div>
+            <div class="panel-body">
+                <p>
+                    Sample code for integrating <a id="link-apple-pay" href="https://developer.apple.com/reference/applepayjs/" rel="noopener" target="_blank" title="View the Apple Pay JS documentation">Apple Pay JS</a> into an ASP.NET Core website.
+                </p>
+                <p>
+                    @await Html.PartialAsync("_GitHubStar", "ApplePayJSSample")
+                    @await Html.PartialAsync("_GitHubFork", "ApplePayJSSample")
+                </p>
+                <p>
+                    <a id="link-repo-apple-pay" href="https://github.com/martincostello/ApplePayJSSample" rel="noopener" target="_blank" title="View the project on GitHub" class="btn btn-default">
+                        Visit project site &raquo;
+                    </a>
+                </p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="panel panel-default">
+            <div class="panel-heading">CDN</div>
+            <div class="panel-body">
+                <p>
+                    The source repository for the content served from this website's CDN.
+                </p>
+                <p>
+                    @await Html.PartialAsync("_GitHubStar", "cdn")
+                    @await Html.PartialAsync("_GitHubFork", "cdn")
+                </p>
+                <p>
+                    <a id="link-repo-cdn" href="https://github.com/martincostello/cdn" rel="noopener" target="_blank" title="View the project on GitHub" class="btn btn-default">
+                        Visit project site &raquo;
+                    </a>
+                </p>
+            </div>
+        </div>
+    </div>
 </div>
 @section scripts {
     <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/src/Website/Views/Shared/_Footer.cshtml
+++ b/src/Website/Views/Shared/_Footer.cshtml
@@ -1,7 +1,7 @@
 ﻿@model SiteOptions
 <hr />
 <footer>
-    <p>
+    <p class="hidden-sm hidden-xs">
         &copy; @Model.Metadata.Author.Name @DateTimeOffset.UtcNow.Year |
         <a id="link-status" href="@Model.ExternalLinks.Status.AbsoluteUri" rel="noopener" target="_blank" title="View site uptime information">
             Site Status &amp; Uptime
@@ -23,4 +23,21 @@
             <lazyimg src="@Url.CdnContent("browserstack.svg", Model)" viewBox="0 0 428.5 92.3" height="20" alt="Sponsored by BrowserStack" title="Sponsored by BrowserStack" />
         </a>
     </p>
+    <div class="row hidden-md hidden-lg">
+        <div class="col-sm-12 col-xs-12">
+            &copy; @Model.Metadata.Author.Name @DateTimeOffset.UtcNow.Year |
+            <a id="link-status" href="@Model.ExternalLinks.Status.AbsoluteUri" rel="noopener" target="_blank" title="View site uptime information">
+                Site Status &amp; Uptime
+            </a>
+        </div>
+        <div class="col-sm-12 col-xs-12">
+            Sponsored by
+            <a id="link-browserstack" href="https://www.browserstack.com/">
+                <noscript>
+                    <img src="@Url.CdnContent("browserstack.svg", Model)" viewBox="0 0 428.5 92.3" height="20" alt="Sponsored by BrowserStack" title="Sponsored by BrowserStack" asp-append-version="true" />
+                </noscript>
+                <lazyimg src="@Url.CdnContent("browserstack.svg", Model)" viewBox="0 0 428.5 92.3" height="20" alt="Sponsored by BrowserStack" title="Sponsored by BrowserStack" />
+            </a>
+        </div>
+    </div>
 </footer>

--- a/src/Website/Views/Shared/_Layout.cshtml
+++ b/src/Website/Views/Shared/_Layout.cshtml
@@ -4,6 +4,8 @@
 <!DOCTYPE html>
 <html lang="en-gb">
 <head prefix="og:http://ogp.me/ns#">
+    @await Html.PartialAsync("_Styles")
+    @await RenderSectionAsync("styles", required: false)
     @{
         string canonicalUri = Context.Request.Canonical();
         string image = ViewBag.MetaImage ?? string.Empty;
@@ -61,8 +63,6 @@
         @RenderBody()
         @await Html.PartialAsync("_Footer", Options)
     </div>
-    @await Html.PartialAsync("_Styles")
-    @await RenderSectionAsync("styles", required: false)
     @await Html.PartialAsync("_Scripts", BowerVersions)
     @await RenderSectionAsync("scripts", required: false)
 </body>

--- a/src/Website/Views/Shared/_Styles.cshtml
+++ b/src/Website/Views/Shared/_Styles.cshtml
@@ -1,15 +1,9 @@
 ﻿@inject BowerVersions BowerVersions
-<environment names="Development">
-    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" asp-append-version="true" />
-</environment>
-<environment names="Staging,Production">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/@BowerVersions["bootstrap"]/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous"
-          asp-fallback-href="~/lib/bootstrap/dist/css/bootstrap.min.css"
-          asp-fallback-test-class="sr-only"
-          asp-fallback-test-property="position"
-          asp-fallback-test-value="absolute" />
-</environment>
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/@BowerVersions["bootstrap"]/flatly/bootstrap.min.css" integrity="sha384-+ENW/yibaokMnme+vBLnHMphUYxHs34h9lpdbSLuAwGkOKFRl4C34WkjazBtb7eT" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/@BowerVersions["bootstrap"]/flatly/bootstrap.min.css" integrity="sha384-+ENW/yibaokMnme+vBLnHMphUYxHs34h9lpdbSLuAwGkOKFRl4C34WkjazBtb7eT" crossorigin="anonymous"
+      asp-fallback-href="~/lib/bootstrap/dist/css/bootstrap.min.css"
+      asp-fallback-test-class="sr-only"
+      asp-fallback-test-property="position"
+      asp-fallback-test-value="absolute" />
 <environment names="Development">
     <link rel="stylesheet" href="~/assets/css/site.css" asp-append-version="true" />
 </environment>

--- a/src/Website/Views/Shared/_Styles.cshtml
+++ b/src/Website/Views/Shared/_Styles.cshtml
@@ -5,8 +5,8 @@
       asp-fallback-test-property="position"
       asp-fallback-test-value="absolute" />
 <environment names="Development">
-    <link rel="stylesheet" href="~/assets/css/site.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/assets/css/site.css" asp-append-version="true" asp-inline="true" asp-minify-inlined="true" />
 </environment>
 <environment names="Staging,Production">
-    <link rel="stylesheet" href="~/assets/css/site.min.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/assets/css/site.min.css" asp-append-version="true" asp-inline="true" />
 </environment>

--- a/src/Website/Views/Tools/Index.cshtml
+++ b/src/Website/Views/Tools/Index.cshtml
@@ -25,12 +25,15 @@
 <noscript>
     <div class="alert alert-warning" role="alert">JavaScript must be enabled in your browser to use these tools.</div>
 </noscript>
+<hr />
 <div>
     @await Html.PartialAsync("_GenerateGuid")
 </div>
+<hr />
 <div>
     @await Html.PartialAsync("_GenerateHash")
 </div>
+<hr />
 <div>
     @await Html.PartialAsync("_GenerateMachineKey")
 </div>

--- a/src/Website/Views/Tools/_GenerateGuid.cshtml
+++ b/src/Website/Views/Tools/_GenerateGuid.cshtml
@@ -13,7 +13,9 @@
                     </span>
                 </div>
             </div>
-            <div class="col-md-2">
+        </div>
+        <div class="form-group">
+            <div class="col-md-offset-2 col-md-2">
                 <a id="generate-guid" class="btn btn-primary" role="button" href="#GenerateGuid" rel="nofollow" title="Generate a new GUID">New GUID</a>
             </div>
         </div>


### PR DESCRIPTION
  * Render CSS tags in ```<head>``` as [recommended by Google](https://developers.google.com/web/fundamentals/performance/critical-rendering-path/page-speed-rules-and-recommendations#put_css_in_the_document_head).
  * Render small local CSS file inline as a ```<style>``` tag using a new TagHelper.
  * Do not render the default Bootstrap CSS file.
  * Improve layout of various pages on mobile.
  * Add new projects.
  * Update technologies on the ```/home/about``` page.