### PR TITLE
Fix Google PageSpeed score

### DIFF
--- a/src/Website/Views/Shared/_Layout.cshtml
+++ b/src/Website/Views/Shared/_Layout.cshtml
@@ -4,8 +4,8 @@
 <!DOCTYPE html>
 <html lang="en-gb">
 <head prefix="og:http://ogp.me/ns#">
-    @await Html.PartialAsync("_Styles")
-    @await RenderSectionAsync("styles", required: false)
+    @await Html.PartialAsync("_StylesHead")
+    @await RenderSectionAsync("stylesHead", required: false)
     @{
         string canonicalUri = Context.Request.Canonical();
         string image = ViewBag.MetaImage ?? string.Empty;
@@ -63,6 +63,8 @@
         @RenderBody()
         @await Html.PartialAsync("_Footer", Options)
     </div>
+    @await Html.PartialAsync("_StylesBody")
+    @await RenderSectionAsync("stylesBody", required: false)
     @await Html.PartialAsync("_Scripts", BowerVersions)
     @await RenderSectionAsync("scripts", required: false)
 </body>

--- a/src/Website/Views/Shared/_StylesBody.cshtml
+++ b/src/Website/Views/Shared/_StylesBody.cshtml
@@ -4,9 +4,3 @@
       asp-fallback-test-class="sr-only"
       asp-fallback-test-property="position"
       asp-fallback-test-value="absolute" />
-<environment names="Development">
-    <link rel="stylesheet" href="~/assets/css/site.css" asp-append-version="true" asp-inline="true" asp-minify-inlined="true" />
-</environment>
-<environment names="Staging,Production">
-    <link rel="stylesheet" href="~/assets/css/site.min.css" asp-append-version="true" asp-inline="true" />
-</environment>

--- a/src/Website/Views/Shared/_StylesBody.cshtml
+++ b/src/Website/Views/Shared/_StylesBody.cshtml
@@ -1,6 +1,24 @@
 ﻿@inject BowerVersions BowerVersions
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/@BowerVersions["bootstrap"]/flatly/bootstrap.min.css" integrity="sha384-+ENW/yibaokMnme+vBLnHMphUYxHs34h9lpdbSLuAwGkOKFRl4C34WkjazBtb7eT" crossorigin="anonymous"
-      asp-fallback-href="~/lib/bootstrap/dist/css/bootstrap.min.css"
-      asp-fallback-test-class="sr-only"
-      asp-fallback-test-property="position"
-      asp-fallback-test-value="absolute" />
+<noscript id="deferred-styles">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/@BowerVersions["bootstrap"]/flatly/bootstrap.min.css" integrity="sha384-+ENW/yibaokMnme+vBLnHMphUYxHs34h9lpdbSLuAwGkOKFRl4C34WkjazBtb7eT" crossorigin="anonymous"
+          asp-fallback-href="~/lib/bootstrap/dist/css/bootstrap.min.css"
+          asp-fallback-test-class="sr-only"
+          asp-fallback-test-property="position"
+          asp-fallback-test-value="absolute" />
+</noscript>
+<script>
+      var loadDeferredStyles = function() {
+        var addStylesNode = document.getElementById("deferred-styles");
+        var replacement = document.createElement("div");
+        replacement.innerHTML = addStylesNode.textContent;
+        document.body.appendChild(replacement)
+        addStylesNode.parentElement.removeChild(addStylesNode);
+      };
+      var raf = requestAnimationFrame || mozRequestAnimationFrame || webkitRequestAnimationFrame || msRequestAnimationFrame;
+      if (raf) {
+          raf(function () { window.setTimeout(loadDeferredStyles, 0); });
+      }
+      else {
+          window.addEventListener("load", loadDeferredStyles);
+      }
+</script>

--- a/src/Website/Views/Shared/_StylesHead.cshtml
+++ b/src/Website/Views/Shared/_StylesHead.cshtml
@@ -1,0 +1,6 @@
+﻿<environment names="Development">
+    <link rel="stylesheet" href="~/assets/css/site.css" asp-append-version="true" asp-inline="true" asp-minify-inlined="true" />
+</environment>
+<environment names="Staging,Production">
+    <link rel="stylesheet" href="~/assets/css/site.min.css" asp-append-version="true" asp-inline="true" />
+</environment>


### PR DESCRIPTION
The changes in #127 actually caused the Google PageSpeed score to regress significantly.

Partially rollback the changes by splitting the partials for styles into a partial for ```<head>``` and another for ```<body>```, and then use the JavaScript recommended [here](https://developers.google.com/speed/docs/insights/OptimizeCSSDelivery#example) to render the CSS using JavaScript.