### PR TITLE
Fix JavaScript loading in production

### DIFF
--- a/src/Website/Views/Shared/_Scripts.cshtml
+++ b/src/Website/Views/Shared/_Scripts.cshtml
@@ -7,21 +7,13 @@
     <script src="~/assets/js/site.js" asp-append-version="true"></script>
 </environment>
 <environment names="Staging,Production">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/@Model["jquery"]/jquery.min.js" integrity="sha256-a23g1Nt4dtEYOj7bR+vTu7+T8VP13humZFBJNIYoEJo=" crossorigin="anonymous" async
-            asp-fallback-src="~/lib/jquery/dist/jquery.min.js"
-            asp-fallback-test="window.jQuery">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/@Model["jquery"]/jquery.min.js" integrity="sha256-a23g1Nt4dtEYOj7bR+vTu7+T8VP13humZFBJNIYoEJo=" crossorigin="anonymous" defer>
     </script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/@Model["bootstrap"]/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous" defer
-            asp-fallback-src="~/lib/bootstrap/dist/js/bootstrap.min.js"
-            asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal">
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/@Model["bootstrap"]/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous" defer>
     </script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/@Model["jquery.lazyload"]/jquery.lazyload.min.js" integrity="sha256-rXnOfjTRp4iAm7hTAxEz3irkXzwZrElV2uRsdJAYjC4=" crossorigin="anonymous" defer
-            asp-fallback-src="~/lib/jquery.lazyload/jquery.lazyload.min.js"
-            asp-fallback-test="window.$.fn.lazyload">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/@Model["jquery.lazyload"]/jquery.lazyload.min.js" integrity="sha256-rXnOfjTRp4iAm7hTAxEz3irkXzwZrElV2uRsdJAYjC4=" crossorigin="anonymous" defer>
     </script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/@Model["moment"]/moment.min.js" integrity="sha384-7pfELK0arQ3VANqV4kiPWPh5wOsrfitjFGF/NdyHXUJ3JJPy/rNhasPtdkaNKhul" crossorigin="anonymous" async
-            asp-fallback-src="~/lib/moment/min/moment.min.js"
-            asp-fallback-test="window.moment">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/@Model["moment"]/moment.min.js" integrity="sha384-7pfELK0arQ3VANqV4kiPWPh5wOsrfitjFGF/NdyHXUJ3JJPy/rNhasPtdkaNKhul" crossorigin="anonymous" defer>
     </script>
     <script src="~/assets/js/site.min.js" asp-append-version="true" defer></script>
 </environment>


### PR DESCRIPTION
Fix async/defer not working as expected from changes in a942f6789a973abaed71449c66ca7ddbcdc5ae9c, so defer all scripts to preserve dependencies.
This also requires the fallback scripts as otherwise they fire immediately, and then fail as the SRI integrity hashes do not match for local files.