### PR TITLE
Remove font from critical CSS

### DIFF
--- a/src/Website/Assets/Styles/css/css.css
+++ b/src/Website/Assets/Styles/css/css.css
@@ -5,7 +5,7 @@
 body {
     background-color: #fff;
     color: #2c3e50;
-    font-family: Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 15px;
 }
 


### PR DESCRIPTION
Remove the ```Lato``` font from the critical CSS to stop a font being downloaded.