### PR TITLE
Use IOptionsSnapshot

### DIFF
--- a/src/Website/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/Website/Extensions/IApplicationBuilderExtensions.cs
@@ -6,6 +6,7 @@ namespace MartinCostello.Website.Extensions
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Options;
     using Middleware;
     using Options;
 
@@ -28,7 +29,7 @@ namespace MartinCostello.Website.Extensions
             this IApplicationBuilder value,
             IHostingEnvironment environment,
             IConfiguration config,
-            SiteOptions options)
+            IOptionsSnapshot<SiteOptions> options)
         {
             return value.UseMiddleware<CustomHttpHeadersMiddleware>(environment, config, options);
         }

--- a/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
@@ -166,7 +166,6 @@ namespace MartinCostello.Website.Middleware
                 { "frame-ancestors", new[] { Csp.None } },
                 { "form-action", new[] { Csp.Self } },
                 { "block-all-mixed-content", Array.Empty<string>() },
-                { "reflected-xss", new[] { "block" } },
                 { "base-uri", new[] { Csp.Self } },
                 { "manifest-src", new[] { Csp.Self } },
             };

--- a/src/Website/Startup.cs
+++ b/src/Website/Startup.cs
@@ -5,7 +5,6 @@ namespace MartinCostello.Website
 {
     using System;
     using Extensions;
-    using Microsoft.ApplicationInsights.AspNetCore;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.CookiePolicy;
     using Microsoft.AspNetCore.Hosting;
@@ -66,8 +65,12 @@ namespace MartinCostello.Website
         /// <param name="app">The <see cref="IApplicationBuilder"/> to use.</param>
         /// <param name="environment">The <see cref="IHostingEnvironment"/> to use.</param>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use.</param>
-        /// <param name="options">The <see cref="SiteOptions"/> to use.</param>
-        public void Configure(IApplicationBuilder app, IHostingEnvironment environment, ILoggerFactory loggerFactory, SiteOptions options)
+        /// <param name="options">The snapshot of <see cref="SiteOptions"/> to use.</param>
+        public void Configure(
+            IApplicationBuilder app,
+            IHostingEnvironment environment,
+            ILoggerFactory loggerFactory,
+            IOptionsSnapshot<SiteOptions> options)
         {
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
 
@@ -155,7 +158,7 @@ namespace MartinCostello.Website
 
             services.AddSingleton<IConfiguration>((_) => Configuration);
             services.AddSingleton<IClock>((_) => SystemClock.Instance);
-            services.AddSingleton((p) => p.GetRequiredService<IOptions<SiteOptions>>().Value);
+            services.AddSingleton((p) => p.GetRequiredService<IOptionsSnapshot<SiteOptions>>().Value);
             services.AddSingleton((p) => new BowerVersions(p.GetRequiredService<IHostingEnvironment>()));
         }
 

--- a/src/Website/Startup.cs
+++ b/src/Website/Startup.cs
@@ -32,8 +32,8 @@ namespace MartinCostello.Website
         public Startup(IHostingEnvironment env)
         {
             var builder = new ConfigurationBuilder()
-                .AddJsonFile("appsettings.json")
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
+                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true)
                 .AddEnvironmentVariables();
 
             bool isDevelopment = env.IsDevelopment();
@@ -158,8 +158,8 @@ namespace MartinCostello.Website
 
             services.AddSingleton<IConfiguration>((_) => Configuration);
             services.AddSingleton<IClock>((_) => SystemClock.Instance);
-            services.AddSingleton((p) => p.GetRequiredService<IOptionsSnapshot<SiteOptions>>().Value);
             services.AddSingleton((p) => new BowerVersions(p.GetRequiredService<IHostingEnvironment>()));
+            services.AddScoped((p) => p.GetRequiredService<IOptionsSnapshot<SiteOptions>>().Value);
         }
 
         /// <summary>


### PR DESCRIPTION
  * Use ```IOptionsSnapshot<T>``` to allow for configuration reloading of strongly-typed options.
  * Allow the configuration to be reloaded if JSON files are changed.
  * Removed ```reflected-xss``` CSP directive that causes warnings in Chrome.