### PR TITLE
Fix the /projects page

### DIFF
--- a/src/Website/Views/Projects/Index.cshtml
+++ b/src/Website/Views/Projects/Index.cshtml
@@ -99,8 +99,7 @@
             <div class="panel-heading">API</div>
             <div class="panel-body">
                 <p>
-                    A <a id="link-api" href="@Options?.ExternalLinks?.Api?.AbsoluteUri" rel="noopener" title="Visit the API" target="_blank">REST API</a>
-                    used as an excercise in implementing an ASP.NET Core website.
+                    A REST API used as an excercise in implementing an ASP.NET Core website.
                 </p>
                 <p>
                     @await Html.PartialAsync("_GitHubStar", "api")

--- a/tests/Website.Tests/appsettings.json
+++ b/tests/Website.Tests/appsettings.json
@@ -13,7 +13,7 @@
     },
     "ContentSecurityPolicyOrigins": {},
     "ExternalLinks": {
-      "Api": "https://api.martincostello.com/",
+      "Api": "/",
       "Blog": "https://blog.martincostello.com/",
       "Cdn": "https://martincostello.azureedge.net/",
       "Status": "http://status.martincostello.com/",


### PR DESCRIPTION
Fix the ```/projects``` page not working since #138 was merged as the page was trying to get the absolute URI of a relative URI.

Wasn't caught by the tests as the test settings still used a full URI.