### PR TITLE
Remove BrowserStack logo from page footer

### DIFF
--- a/src/Website/Views/Shared/_Footer.cshtml
+++ b/src/Website/Views/Shared/_Footer.cshtml
@@ -15,29 +15,15 @@
             @GitMetadata.Branch
         </a>
         <span id="build-date" data-format="YYYY-MM-DD HH:mm Z" data-timestamp="@GitMetadata.Timestamp.ToString("u", CultureInfo.InvariantCulture)"></span>
-        | Sponsored by
-        <a id="link-browserstack" href="https://www.browserstack.com/">
-            <noscript>
-                <img src="@Url.CdnContent("browserstack.svg", Model)" viewBox="0 0 428.5 92.3" height="20" alt="Sponsored by BrowserStack" title="Sponsored by BrowserStack" asp-append-version="true" />
-            </noscript>
-            <lazyimg src="@Url.CdnContent("browserstack.svg", Model)" viewBox="0 0 428.5 92.3" height="20" alt="Sponsored by BrowserStack" title="Sponsored by BrowserStack" />
-        </a>
     </p>
     <div class="row hidden-md hidden-lg">
         <div class="col-sm-12 col-xs-12">
-            &copy; @Model.Metadata.Author.Name @DateTimeOffset.UtcNow.Year |
-            <a id="link-status" href="@Model.ExternalLinks.Status.AbsoluteUri" rel="noopener" target="_blank" title="View site uptime information">
-                Site Status &amp; Uptime
-            </a>
-        </div>
-        <div class="col-sm-12 col-xs-12">
-            Sponsored by
-            <a id="link-browserstack" href="https://www.browserstack.com/">
-                <noscript>
-                    <img src="@Url.CdnContent("browserstack.svg", Model)" viewBox="0 0 428.5 92.3" height="20" alt="Sponsored by BrowserStack" title="Sponsored by BrowserStack" asp-append-version="true" />
-                </noscript>
-                <lazyimg src="@Url.CdnContent("browserstack.svg", Model)" viewBox="0 0 428.5 92.3" height="20" alt="Sponsored by BrowserStack" title="Sponsored by BrowserStack" />
-            </a>
+            <p>
+                &copy; @Model.Metadata.Author.Name @DateTimeOffset.UtcNow.Year |
+                <a id="link-status" href="@Model.ExternalLinks.Status.AbsoluteUri" rel="noopener" target="_blank" title="View site uptime information">
+                    Site Status &amp; Uptime
+                </a>
+            </p>
         </div>
     </div>
 </footer>


### PR DESCRIPTION
Remove the BrowserStack logo from the page footer as the free Automate subscription has now expired.