### PR TITLE
Visual Studio 2017 fixes

### DIFF
--- a/Website.Common.props
+++ b/Website.Common.props
@@ -7,7 +7,6 @@
     <CodeAnalysisRuleSet>../../Website.ruleset</CodeAnalysisRuleSet>
     <Company>https://github.com/martincostello/website</Company>
     <Copyright>Martin Costello (c) 2016-2017</Copyright>
-    <DefineConstants>$(DefineConstants)</DefineConstants>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/Website.Common.props
+++ b/Website.Common.props
@@ -21,7 +21,6 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>
     <RunCodeAnalysis>true</RunCodeAnalysis>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <WarningsAsErrors>true</WarningsAsErrors>

--- a/Website.Common.props
+++ b/Website.Common.props
@@ -19,7 +19,6 @@
     <PackageTags></PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
     <VersionPrefix>1.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <WarningsAsErrors>true</WarningsAsErrors>

--- a/src/Website/Website.csproj
+++ b/src/Website/Website.csproj
@@ -1,5 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
-  <Import Project="..\..\Website.Common.props" />
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <AssemblyName>Website</AssemblyName>
     <AssemblyTitle>martincostello.com</AssemblyTitle>
@@ -9,6 +8,7 @@
     <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <Summary>Martin Costello's website</Summary>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <UserSecretsId>martincostello.com</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
@@ -57,4 +57,5 @@
       <Content Include="wwwroot/**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Content)" />
     </ItemGroup>
   </Target>
+  <Import Project="..\..\Website.Common.props" />
 </Project>

--- a/src/Website/Website.csproj
+++ b/src/Website/Website.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <Import Project="..\..\Website.Common.props" />
   <PropertyGroup>
     <AssemblyName>Website</AssemblyName>
     <AssemblyTitle>martincostello.com</AssemblyTitle>
@@ -57,5 +58,4 @@
       <Content Include="wwwroot/**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Content)" />
     </ItemGroup>
   </Target>
-  <Import Project="..\..\Website.Common.props" />
 </Project>

--- a/src/Website/Website.csproj
+++ b/src/Website/Website.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <Compile Include="..\..\AssemblyVersion.cs;..\..\CommonAssemblyInfo.cs" />
     <Content Include="parameters.xml" CopyToOutputDirectory="PreserveNewest" />
+    <Content Update="appsettings.json;bower.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="1.0.0-msbuild3-final" />

--- a/tests/Website.Tests/Website.Tests.csproj
+++ b/tests/Website.Tests/Website.Tests.csproj
@@ -5,6 +5,7 @@
     <AssemblyTitle>martincostello.com.Tests</AssemblyTitle>
     <Description>Tests for https://martincostello.com/</Description>
     <PackageId>Website.Tests</PackageId>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
     <Summary>Tests for Martin Costello's website</Summary>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>

--- a/tests/Website.Tests/Website.Tests.csproj
+++ b/tests/Website.Tests/Website.Tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="NodaTime.Testing" Version="2.0.0-beta20170123" />
     <PackageReference Include="Shouldly" Version="2.8.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="xunit" Version="2.2.0-beta6-build3495" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta6-build1242" />
+    <PackageReference Include="xunit" Version="2.2.0-rc4-build3536" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-rc5-build1271" />
   </ItemGroup>
 </Project>

--- a/tests/Website.Tests/Website.Tests.csproj
+++ b/tests/Website.Tests/Website.Tests.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\Website.Common.props" />
   <PropertyGroup>
     <AssemblyName>Website.Tests</AssemblyName>
     <AssemblyTitle>martincostello.com.Tests</AssemblyTitle>
@@ -24,5 +25,4 @@
     <PackageReference Include="xunit" Version="2.2.0-beta6-build3495" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta6-build1242" />
   </ItemGroup>
-  <Import Project="..\..\Website.Common.props" />
 </Project>

--- a/tests/Website.Tests/Website.Tests.csproj
+++ b/tests/Website.Tests/Website.Tests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\Website.Common.props" />
   <PropertyGroup>
     <AssemblyName>Website.Tests</AssemblyName>
     <AssemblyTitle>martincostello.com.Tests</AssemblyTitle>
     <Description>Tests for https://martincostello.com/</Description>
     <PackageId>Website.Tests</PackageId>
     <Summary>Tests for Martin Costello's website</Summary>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyVersion.cs;..\..\CommonAssemblyInfo.cs" />
@@ -24,4 +24,5 @@
     <PackageReference Include="xunit" Version="2.2.0-beta6-build3495" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta6-build1242" />
   </ItemGroup>
+  <Import Project="..\..\Website.Common.props" />
 </Project>

--- a/tests/Website.Tests/Website.Tests.csproj
+++ b/tests/Website.Tests/Website.Tests.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170217-05" />
     <PackageReference Include="NodaTime" Version="2.0.0-beta20170123" />
     <PackageReference Include="NodaTime.Testing" Version="2.0.0-beta20170123" />
     <PackageReference Include="Shouldly" Version="2.8.2" />


### PR DESCRIPTION
Various fixes for running the project in Visual Studio 2017 and a few other bits:
  1. Fix projects appearing as needing migration.
  1. Fix NuGet packages not restoring.
  1. Fix xunit tests that load Razor views failing.
  1. Fix StyleCop warnings from auto-generated files.
  1. Fix missing JSON files from output folder.
  1. Fix tests missing from AppVeyor build logs.