### PR TITLE
Update to xunit 2.2.0

### DIFF
--- a/tests/Website.Tests/Website.Tests.csproj
+++ b/tests/Website.Tests/Website.Tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="NodaTime.Testing" Version="2.0.0-beta20170123" />
     <PackageReference Include="Shouldly" Version="2.8.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="xunit" Version="2.2.0-rc4-build3536" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-rc5-build1271" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Update to the final release of xunit 2.2.0.

This should pick up the fix for test reporting in AppVeyor.