### PR TITLE
Add options for Certificate Transparency

### DIFF
--- a/src/Website/Options/CertificateTransparencyOptions.cs
+++ b/src/Website/Options/CertificateTransparencyOptions.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Website.Options
+{
+    using System;
+
+    /// <summary>
+    /// A class representing the options to use for the <c>Expect-CT</c>
+    /// HTTP response header. This class cannot be inherited.
+    /// </summary>
+    public sealed class CertificateTransparencyOptions
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to enforce certificate transparency.
+        /// </summary>
+        public bool Enforce { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum period of time to cache the policy for.
+        /// </summary>
+        public TimeSpan MaxAge { get; set; }
+    }
+}

--- a/src/Website/Options/SiteOptions.cs
+++ b/src/Website/Options/SiteOptions.cs
@@ -21,6 +21,11 @@ namespace MartinCostello.Website.Options
         public ApiOptions Api { get; set; }
 
         /// <summary>
+        /// Gets or sets the certificate transparency options to use.
+        /// </summary>
+        public CertificateTransparencyOptions CertificateTransparency { get; set; }
+
+        /// <summary>
         /// Gets or sets the Content Security Policy origins for the site.
         /// </summary>
         public IDictionary<string, IList<string>> ContentSecurityPolicyOrigins { get; set; }

--- a/src/Website/appsettings.json
+++ b/src/Website/appsettings.json
@@ -26,6 +26,10 @@
         "Origins": [ "https://martincostello.com", "https://dev.martincostello.com", "https://staging.martincostello.com" ]
       }
     },
+    "CertificateTransparency": {
+      "Enforce": false,
+      "MaxAge": "00.00:30:00"
+    },
     "ContentSecurityPolicyOrigins": {
       "child-src": [ "buttons.github.io", "platform.linkedin.com", "platform.twitter.com" ],
       "connect-src": [ "dc.services.visualstudio.com" ],

--- a/tests/Website.Tests/testsettings.json
+++ b/tests/Website.Tests/testsettings.json
@@ -11,6 +11,10 @@
     "Analytics": {
       "Google": "UA-42907618-1"
     },
+    "CertificateTransparency": {
+      "Enforce": false,
+      "MaxAge": "00.00:30:00"
+    },
     "ContentSecurityPolicyOrigins": {},
     "ExternalLinks": {
       "Api": "/",


### PR DESCRIPTION
  * Add options for Certificate Transparency to control the value of the ```Expect-CT``` header.
  * Set the ```max-age``` of the ```Expect-CT``` policy to 30 minutes.