### PR TITLE
Fix inline source map 404

### DIFF
--- a/src/Website/Views/Shared/_Meta.cshtml
+++ b/src/Website/Views/Shared/_Meta.cshtml
@@ -1,6 +1,10 @@
 ﻿@using Microsoft.AspNetCore.Hosting
 @model MetaModel
+@inject IConfiguration Config
 @inject IHostingEnvironment Hosting
+@{
+    bool renderGA = string.Equals(Config.AzureEnvironment(), "production", StringComparison.OrdinalIgnoreCase);
+}
     <title>@Model.Title</title>
     <meta http-equiv="cache-control" content="no-cache, no-store" />
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -44,7 +48,7 @@
     <meta name="twitter:title" content="@Model.Title" />
     <meta name="twitter:url" content="@Model.CanonicalUri" />
     <meta name="application-name" content="@Model.SiteName" />
-    <meta name="google-analytics" content="@(Hosting.IsProduction() ? Options.Analytics.Google : string.Empty)" />
+    <meta name="google-analytics" content="@(renderGA ? Options.Analytics.Google : string.Empty)" />
     <meta name="google-site-verification" content="ao6JIWbKFHZ8DmbV52hf43MrjiHCFRf0GiJYYHDeRMo" />
     <meta name="google-site-verification" content="I9S9DiGCLTG_JdMlSwt2YnNVcyFPo1DT1jeHa_X-p_0" />
     <meta name="google-site-verification" content="ji6SNsPQEbNQmF252sQgQFswh-b6cDnNOa3AHvgo4J0" />


### PR DESCRIPTION
  1. Fix-up source map file paths in inline CSS.
  1. Only render GA ```meta``` tag content in Azure Production.