### PR TITLE
Cache npm modules in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ install:
   - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
   - curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
   - export PATH="$DOTNET_INSTALL_DIR:$PATH"
-  - npm install -g npm
-  - npm install -g gulp
   - dotnet --info
+  - npm install -g npm@4.5.0
+  - npm install -g gulp@3.9.1
 
 script:
   - ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ branches:
   only:
     - master
 
+cache:
+  directories:
+    - /home/travis/.npm
+    - /home/travis/.nuget/packages
+    - src/Website/node_modules
+
 addons:
   apt:
     packages:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,8 +16,8 @@ cache:
   - '%APPDATA%\npm-cache'
 
 install:
-  - ps: npm install -g npm --loglevel=error
-  - ps: npm install -g gulp --loglevel=error
+  - ps: npm install -g npm@4.5.0 --loglevel=error
+  - ps: npm install -g gulp@3.9.1 --loglevel=error
 
 build_script:
   - ps: .\Build.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,11 @@ branches:
   only:
     - master
 
+cache:
+  - src\Website\node_modules
+  - '%APPDATA%\npm\node_modules'
+  - '%APPDATA%\npm-cache'
+
 install:
   - ps: npm install -g npm --loglevel=error
   - ps: npm install -g gulp --loglevel=error


### PR DESCRIPTION
  * Cache npm modules in AppVeyor and Travis CI to improve build times.
  * Pin gulp and npm to a specific version instead of using "latest".