### PR TITLE
Add redirect to image that causes 404

### DIFF
--- a/src/Website/Controllers/RedirectController.cs
+++ b/src/Website/Controllers/RedirectController.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Website.Controllers
+{
+    using Extensions;
+    using Microsoft.AspNetCore.Mvc;
+    using Options;
+
+    /// <summary>
+    /// A class representing the controller for redirected resources.
+    /// </summary>
+    public class RedirectController : Controller
+    {
+        /// <summary>
+        /// The <see cref="SiteOptions"/> to use. This field is read-only.
+        /// </summary>
+        private readonly SiteOptions _options;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RedirectController"/> class.
+        /// </summary>
+        /// <param name="options">The options to use.</param>
+        public RedirectController(SiteOptions options)
+        {
+            _options = options;
+        }
+
+        [HttpGet]
+        [Route("Content/browserstack.svg")]
+        public IActionResult Browserstack() => Redirect(Url.CdnContent("browserstack.svg", _options));
+    }
+}

--- a/src/Website/Extensions/IUrlHelperExtensions.cs
+++ b/src/Website/Extensions/IUrlHelperExtensions.cs
@@ -21,7 +21,7 @@ namespace MartinCostello.Website.Extensions
         public static string AbsoluteContent(this IUrlHelper value, string contentPath)
         {
             var request = value.ActionContext.HttpContext.Request;
-            return value.ToAbsolute(request.Host.Value, contentPath);
+            return value.ToAbsolute(request.Host.Value, contentPath, forceHttps: false);
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace MartinCostello.Website.Extensions
             }
 
             // Azure Blob storage is case-sensitive, so force all URLs to lowercase
-            string url = value.ToAbsolute(cdn.Host, contentPath.ToLowerInvariant());
+            string url = value.ToAbsolute(cdn.Host, contentPath.ToLowerInvariant(), forceHttps: true);
 
             // asp-append-version="true" does not work for non-local resources
             if (appendVersion)
@@ -58,12 +58,15 @@ namespace MartinCostello.Website.Extensions
         /// Converts a virtual (relative) path to an absolute URI.
         /// </summary>
         /// <param name="value">The <see cref="IUrlHelper"/>.</param>
+        /// <param name="host">The hostname.</param>
         /// <param name="contentPath">The virtual path of the content.</param>
+        /// <param name="forceHttps">Whether to force the use of HTTPS.</param>
         /// <returns>The application absolute URI.</returns>
-        private static string ToAbsolute(this IUrlHelper value, string host, string contentPath)
+        private static string ToAbsolute(this IUrlHelper value, string host, string contentPath, bool forceHttps)
         {
             var request = value.ActionContext.HttpContext.Request;
-            return new Uri(new Uri(request.Scheme + "://" + host), value.Content(contentPath)).ToString();
+            var scheme = forceHttps ? "https" : request.Scheme;
+            return new Uri(new Uri($"{scheme}://{host}"), value.Content(contentPath)).ToString();
         }
     }
 }

--- a/tests/Website.Tests/Integration/ResourceTests.cs
+++ b/tests/Website.Tests/Integration/ResourceTests.cs
@@ -63,6 +63,17 @@ namespace MartinCostello.Website.Integration
             }
         }
 
+        [Theory]
+        [InlineData("/Content/browserstack.svg", "https://martincostello.azureedge.net/browserstack.svg")]
+        public async Task Resource_Is_Redirect(string requestUri, string location)
+        {
+            using (var response = await Fixture.Client.GetAsync(requestUri))
+            {
+                Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+                Assert.StartsWith(location, response.Headers.Location?.OriginalString);
+            }
+        }
+
         [Fact]
         public async Task Response_Headers_Contains_Expected_Headers()
         {


### PR DESCRIPTION
  * Add redirect to CDN for image request from somewhere that causes a 404.
  * Force CDN URLs to use HTTPS.
  * Add missing XML documentation for parameter.

Resolves #179.