### PR TITLE
Explicitly allow HTTP HEAD for anti-crawlers

### DIFF
--- a/src/Website/Controllers/ErrorController.cs
+++ b/src/Website/Controllers/ErrorController.cs
@@ -60,6 +60,8 @@ namespace MartinCostello.Website.Controllers
         /// <returns>
         /// The result for the action.
         /// </returns>
+        [HttpGet]
+        [HttpHead]
         [Route("account/login")]
         [Route("admin.php")]
         [Route("admin/login.php")]


### PR DESCRIPTION
Explicitly allow HTTP HEAD for the anti-crawler routes so it does not generate a 404.