### PR TITLE
Update CDN

### DIFF
--- a/src/Website/Views/Home/About.cshtml
+++ b/src/Website/Views/Home/About.cshtml
@@ -36,7 +36,7 @@
 <div class="row">
     <div class="col-md-3 col-sm-12 col-xs-12">
         <h4 class="hidden-xs hidden-sm">GitHub</h4>
-        <a class="github-button hidden-xs hidden-sm" href="https://github.com/martincostello" rel="noopener" target="_blank" data-style="mega" data-count-href="/martincostello/followers" data-count-api="/users/martincostello#followers" data-count-aria-label="# followers on GitHub" aria-label="Follow @@martincostello on GitHub">Follow @@martincostello</a>
+        <a class="github-button hidden-xs hidden-sm" href="https://github.com/martincostello" rel="noopener" target="_blank" data-show-count="true" data-size="large" aria-label="Follow @@martincostello on GitHub">Follow @@martincostello</a>
     </div>
     <div class="col-md-3 hidden-xs hidden-sm">
         <h4>LinkedIn</h4>

--- a/src/Website/Views/Projects/_GitHubFork.cshtml
+++ b/src/Website/Views/Projects/_GitHubFork.cshtml
@@ -15,4 +15,4 @@
         project = Model;
     }
 }
-<a class="github-button" href="https://github.com/@user/@project/fork" data-icon="octicon-repo-forked" data-style="mega" data-count-href="/@user/@project/network" data-count-api="/repos/@user/@project#forks_count" data-count-aria-label="# forks on GitHub" aria-label="Fork @user/@project on GitHub">Fork</a>
+<a class="github-button" href="https://github.com/@user/@project/fork" data-icon="octicon-repo-forked" data-show-count="true" data-size="large" aria-label="Fork @user/@project on GitHub">Fork</a>

--- a/src/Website/Views/Projects/_GitHubStar.cshtml
+++ b/src/Website/Views/Projects/_GitHubStar.cshtml
@@ -15,4 +15,4 @@
         project = Model;
     }
 }
-<a class="github-button" href="https://github.com/@user/@project" data-icon="octicon-star" data-style="mega" data-count-href="/@user/@project/stargazers" data-count-api="/repos/@user/@project#stargazers_count" data-count-aria-label="# stargazers on GitHub" aria-label="Star @user/@project on GitHub">Star</a>
+<a class="github-button" href="https://github.com/@user/@project" data-icon="octicon-star" data-show-count="true" data-size="large" aria-label="Star @user/@project on GitHub">Star</a>

--- a/src/Website/appsettings.json
+++ b/src/Website/appsettings.json
@@ -36,7 +36,7 @@
       "connect-src": [ "dc.services.visualstudio.com" ],
       "default-src": [ "buttons.github.io", "maxcdn.bootstrapcdn.com", "platform.linkedin.com", "platform.twitter.com" ],
       "font-src": [ "ajax.googleapis.com", "fonts.googleapis.com", "fonts.gstatic.com", "maxcdn.bootstrapcdn.com" ],
-      "img-src": [ "stackoverflow.com", "static.licdn.com", "stats.g.doubleclick.net", "syndication.twitter.com", "www.google-analytics.com", "www.linkedin.com" ],
+      "img-src": [ "martincostello.azureedge.net", "stackoverflow.com", "static.licdn.com", "stats.g.doubleclick.net", "syndication.twitter.com", "www.google-analytics.com", "www.linkedin.com" ],
       "object-src": [ "ajax.cdnjs.com" ],
       "script-src": [ "ajax.googleapis.com", "api.github.com cdnjs.cloudflare.com", "az416426.vo.msecnd.net", "buttons.github.io", "maxcdn.bootstrapcdn.com", "platform.linkedin.com", "platform.twitter.com", "www.google-analytics.com" ],
       "style-src": [ "ajax.googleapis.com", "buttons.github.io", "fonts.googleapis.com", "maxcdn.bootstrapcdn.com" ]
@@ -44,7 +44,7 @@
     "ExternalLinks": {
       "Api": "/",
       "Blog": "https://blog.martincostello.com/",
-      "Cdn": "https://martincostello.azureedge.net/",
+      "Cdn": "https://cdn.martincostello.com/",
       "Status": "http://status.martincostello.com/",
       "Reports": {
         "ContentSecurityPolicy": "https://martincostello.report-uri.io/r/default/csp/enforce",

--- a/src/Website/tsconfig.json
+++ b/src/Website/tsconfig.json
@@ -4,10 +4,11 @@
     "inlineSources": true,
     "inlineSourceMap": true,
     "noEmitOnError": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
     "outDir": "./wwwroot/Assets/js",
     "removeComments": true,
     "sourceMap": false,
-    "strict": true,
     "target": "es5"
   },
   "exclude": [


### PR DESCRIPTION
  * Update to use `cdn.martincostello.com` now that HTTPS is supported.
  * Fix JavaScript warnings from github-badges.
  * Workaround Visual Studio 2017 not supporting TypeScript 2.3.x options.