### PR TITLE
Add opt-in setting to enable Public-Key-Pins

### DIFF
--- a/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
@@ -120,6 +120,11 @@ namespace MartinCostello.Website.Middleware
 
                         if (!string.IsNullOrWhiteSpace(_publicKeyPins))
                         {
+                            if (_options.Value.PublicKeyPins.IsEnabled)
+                            {
+                                context.Response.Headers.Add("Public-Key-Pins", _publicKeyPins);
+                            }
+
                             context.Response.Headers.Add("Public-Key-Pins-Report-Only", _publicKeyPins);
                         }
                     }

--- a/src/Website/Options/PublicKeyPinsOptions.cs
+++ b/src/Website/Options/PublicKeyPinsOptions.cs
@@ -12,6 +12,11 @@ namespace MartinCostello.Website.Options
     public sealed class PublicKeyPinsOptions
     {
         /// <summary>
+        /// Gets or sets a value indicating whether public key pins is enabled, rather than report-only.
+        /// </summary>
+        public bool IsEnabled { get; set; }
+
+        /// <summary>
         /// Gets or sets the maximum period of time to cache pins for.
         /// </summary>
         public TimeSpan MaxAge { get; set; }

--- a/src/Website/appsettings.json
+++ b/src/Website/appsettings.json
@@ -77,6 +77,7 @@
       "Type": "website"
     },
     "PublicKeyPins": {
+      "IsEnabled": false,
       "MaxAge": "60.00:00:00",
       "IncludeSubdomains": false,
       "Sha256Hashes": [


### PR DESCRIPTION
Add an opt-in setting to emit the `Public-Key-Pins` HTTP response header.

Relates to #78.