### PR TITLE
Fix report-uri for Public-Key-Pins

### DIFF
--- a/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
@@ -56,6 +56,11 @@ namespace MartinCostello.Website.Middleware
         private readonly string _publicKeyPins;
 
         /// <summary>
+        /// The current <c>Public-Key-Pins-Report-Only</c> HTTP response header value. This field is read-only.
+        /// </summary>
+        private readonly string _publicKeyPinsReportOnly;
+
+        /// <summary>
         /// The name of the current hosting environment. This field is read-only.
         /// </summary>
         private readonly string _environmentName;
@@ -87,8 +92,11 @@ namespace MartinCostello.Website.Middleware
 
             _contentSecurityPolicy = BuildContentSecurityPolicy(_isProduction, false, options.Value);
             _contentSecurityPolicyReportOnly = BuildContentSecurityPolicy(_isProduction, true, options.Value);
+
             _expectCTValue = BuildExpectCT(options.Value);
-            _publicKeyPins = BuildPublicKeyPins(options.Value);
+
+            _publicKeyPins = BuildPublicKeyPins(options.Value, reportOnly: false);
+            _publicKeyPinsReportOnly = BuildPublicKeyPins(options.Value, reportOnly: true);
         }
 
         /// <summary>
@@ -118,14 +126,14 @@ namespace MartinCostello.Website.Middleware
                         context.Response.Headers.Add("Expect-CT", _expectCTValue);
                         context.Response.Headers.Add("Strict-Transport-Security", "max-age=31536000");
 
-                        if (!string.IsNullOrWhiteSpace(_publicKeyPins))
+                        if (_options.Value.PublicKeyPins.IsEnabled && !string.IsNullOrWhiteSpace(_publicKeyPins))
                         {
-                            if (_options.Value.PublicKeyPins.IsEnabled)
-                            {
-                                context.Response.Headers.Add("Public-Key-Pins", _publicKeyPins);
-                            }
+                            context.Response.Headers.Add("Public-Key-Pins", _publicKeyPins);
+                        }
 
-                            context.Response.Headers.Add("Public-Key-Pins-Report-Only", _publicKeyPins);
+                        if (!string.IsNullOrWhiteSpace(_publicKeyPinsReportOnly))
+                        {
+                            context.Response.Headers.Add("Public-Key-Pins-Report-Only", _publicKeyPinsReportOnly);
                         }
                     }
 
@@ -261,10 +269,11 @@ namespace MartinCostello.Website.Middleware
         /// Builds the value to use for the <c>Public-Key-Pins</c> HTTP response header.
         /// </summary>
         /// <param name="options">The current site configuration options.</param>
+        /// <param name="reportOnly">Whether to generate the header as report-only.</param>
         /// <returns>
         /// A <see cref="string"/> containing the <c>Public-Key-Pins</c> value to use.
         /// </returns>
-        private static string BuildPublicKeyPins(SiteOptions options)
+        private static string BuildPublicKeyPins(SiteOptions options, bool reportOnly)
         {
             var builder = new StringBuilder();
 
@@ -282,9 +291,14 @@ namespace MartinCostello.Website.Middleware
                     builder.Append(" includeSubDomains;");
                 }
 
-                if (options?.ExternalLinks?.Reports?.PublicKeyPinsReportOnly != null)
+                if (reportOnly && options?.ExternalLinks?.Reports?.PublicKeyPinsReportOnly != null)
                 {
                     builder.Append($" report-uri=\"{options.ExternalLinks.Reports.PublicKeyPinsReportOnly}\";");
+                }
+
+                if (!reportOnly)
+                {
+                    builder.Append($" report-uri=\"{options.ExternalLinks.Reports.PublicKeyPins}\";");
                 }
             }
 


### PR DESCRIPTION
Fix incorrect report URI being used for the `Public-Key-Pins` HTTP response header.

Relates to #186 for #78.