### PR TITLE
Update to .NET Core 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 
 env:
   global:
-    - CLI_VERSION=1.0.4
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
     - NUGET_XMLDOC_MODE=skip
 
@@ -27,12 +26,8 @@ addons:
     - libunwind8
 
 install:
-  - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
-  - curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
-  - export PATH="$DOTNET_INSTALL_DIR:$PATH"
-  - dotnet --info
   - npm install -g npm@4.5.0
   - npm install -g gulp@3.9.1
 
 script:
-  - ./build.sh
+  - ./build.sh --restore-packages

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,46 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        {
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceRoot}/src/Website/bin/Debug/netcoreapp2.0/Website.dll",
+            "args": [],
+            "cwd": "${workspaceRoot}/src/Website",
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart",
+            "launchBrowser": {
+                "enabled": true,
+                "args": "${auto-detect-url}",
+                "windows": {
+                    "command": "cmd.exe",
+                    "args": "/C start ${auto-detect-url}"
+                },
+                "osx": {
+                    "command": "open"
+                },
+                "linux": {
+                    "command": "xdg-open"
+                }
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceRoot}/src/Website/Views"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.1.0",
+    "command": "dotnet",
+    "isShellCommand": true,
+    "args": [],
+    "tasks": [
+        {
+            "taskName": "build",
+            "args": [
+                "${workspaceRoot}/src/Website/Website.csproj"
+            ],
+            "isBuildCommand": true,
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/Build.ps1
+++ b/Build.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 
 $solutionPath = Split-Path $MyInvocation.MyCommand.Definition
 $solutionFile = Join-Path $solutionPath "Website.sln"
-$dotnetVersion = "2.0.0-preview2-006120"
+$dotnetVersion = "2.0.0-preview2-006497"
 
 if ($OutputPath -eq "") {
     $OutputPath = Join-Path "$(Convert-Path "$PSScriptRoot")" "artifacts"

--- a/Build.ps1
+++ b/Build.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 
 $solutionPath = Split-Path $MyInvocation.MyCommand.Definition
 $solutionFile = Join-Path $solutionPath "Website.sln"
-$dotnetVersion = "2.0.0-preview2-006497"
+$dotnetVersion = "2.0.0"
 
 if ($OutputPath -eq "") {
     $OutputPath = Join-Path "$(Convert-Path "$PSScriptRoot")" "artifacts"

--- a/Build.ps1
+++ b/Build.ps1
@@ -43,7 +43,7 @@ if ($installDotNetSdk -eq $true) {
     if (!(Test-Path $env:DOTNET_INSTALL_DIR)) {
         mkdir $env:DOTNET_INSTALL_DIR | Out-Null
         $installScript = Join-Path $env:DOTNET_INSTALL_DIR "install.ps1"
-        Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile $installScript
+        Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/release/2.0.0/scripts/obtain/dotnet-install.ps1" -OutFile $installScript
         & $installScript -Version "$dotnetVersion" -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath
     }
 

--- a/Build.ps1
+++ b/Build.ps1
@@ -12,8 +12,7 @@ $ErrorActionPreference = "Stop"
 
 $solutionPath = Split-Path $MyInvocation.MyCommand.Definition
 $solutionFile = Join-Path $solutionPath "Website.sln"
-$framework = "netcoreapp1.1"
-$dotnetVersion = "1.0.4"
+$dotnetVersion = "2.0.0-preview1-005977"
 
 if ($OutputPath -eq "") {
     $OutputPath = Join-Path "$(Convert-Path "$PSScriptRoot")" "artifacts"

--- a/Build.ps1
+++ b/Build.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Stop"
 
 $solutionPath = Split-Path $MyInvocation.MyCommand.Definition
 $solutionFile = Join-Path $solutionPath "Website.sln"
-$dotnetVersion = "2.0.0-preview1-005977"
+$dotnetVersion = "2.0.0-preview2-006120"
 
 if ($OutputPath -eq "") {
     $OutputPath = Join-Path "$(Convert-Path "$PSScriptRoot")" "artifacts"

--- a/Build.ps1
+++ b/Build.ps1
@@ -66,7 +66,7 @@ function DotNetTest {
     param([string]$Project)
 
     if ($DisableCodeCoverage -eq $true) {
-        & $dotnet test $Project --output $OutputPath --framework $framework
+        & $dotnet test $Project --output $OutputPath
     }
     else {
 
@@ -103,10 +103,10 @@ function DotNetPublish {
     param([string]$Project)
     $publishPath = (Join-Path $OutputPath "publish")
     if ($VersionSuffix) {
-        & $dotnet publish $Project --output $publishPath --framework $framework --configuration $Configuration --version-suffix "$VersionSuffix"
+        & $dotnet publish $Project --output $publishPath --configuration $Configuration --version-suffix "$VersionSuffix"
     }
     else {
-        & $dotnet publish $Project --output $publishPath --framework $framework --configuration $Configuration
+        & $dotnet publish $Project --output $publishPath --configuration $Configuration
     }
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet publish failed with exit code $LASTEXITCODE"

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="DotNet-Core-MyGet" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/Website.Common.props
+++ b/Website.Common.props
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
   </ItemGroup>
@@ -6,10 +6,11 @@
     <Authors>Martin Costello</Authors>
     <CodeAnalysisRuleSet>../../Website.ruleset</CodeAnalysisRuleSet>
     <Company>https://github.com/martincostello/website</Company>
-    <Copyright>Martin Costello (c) 2016-2017</Copyright>
+    <Copyright>Martin Costello (c) 2016-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <LangVersion>latest</LangVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageIconUrl>https://martincostello.com/favicon.ico</PackageIconUrl>
     <PackageProjectUrl>https://github.com/martincostello/website</PackageProjectUrl>
@@ -20,7 +21,8 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <TypeScriptToolsVersion>latest</TypeScriptToolsVersion>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(CI)' != '' or '$(TF_BUILD)' != '' ">

--- a/Website.Common.props
+++ b/Website.Common.props
@@ -10,7 +10,6 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <LangVersion>latest</LangVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageIconUrl>https://martincostello.com/favicon.ico</PackageIconUrl>
     <PackageProjectUrl>https://github.com/martincostello/website</PackageProjectUrl>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ os: Visual Studio 2017
 version: 1.0.{build}
 
 environment:
-  CLI_VERSION: 1.0.4
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   NUGET_XMLDOC_MODE: skip
 

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,56 @@
-#!/bin/sh
-export artifacts=$(dirname "$(readlink -f "$0")")/artifacts
-export configuration=Release
+#!/usr/bin/env bash
 
-dotnet restore Website.sln --verbosity minimal || exit 1
-dotnet build Website.sln --output $artifacts --configuration $configuration || exit 1
-dotnet test tests/Website.Tests/Website.Tests.csproj --output $artifacts --configuration $configuration || exit 1
-dotnet publish src/Website/Website.csproj --output $artifacts --configuration $configuration || exit 1
+root=$(cd "$(dirname "$0")"; pwd -P)
+artifacts=$root/artifacts
+configuration=Release
+
+restorePackages=0
+skipTests=0
+
+while :; do
+    if [ $# -le 0 ]; then
+        break
+    fi
+
+    lowerI="$(echo $1 | awk '{print tolower($0)}')"
+    case $lowerI in
+        -\?|-h|--help)
+            echo "./build.sh [--restore-packages] [--skip-tests]"
+            exit 1
+            ;;
+
+        --restore-packages)
+            restorePackages=1
+            ;;
+
+        --skip-tests)
+            skipTests=1
+            ;;
+
+        *)
+            __UnprocessedBuildArgs="$__UnprocessedBuildArgs $1"
+            ;;
+    esac
+
+    shift
+done
+
+export CLI_VERSION="2.0.0-preview1-005977"
+export DOTNET_INSTALL_DIR="$root/.dotnetcli"
+export PATH="$DOTNET_INSTALL_DIR:$PATH"
+
+dotnet_version=$(dotnet --version)
+
+if [ "$dotnet_version" != "$CLI_VERSION" ]; then
+    curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
+fi
+
+if [ $restorePackages == 1 ]; then
+    dotnet restore ./Website.sln --verbosity minimal || exit 1
+fi
+
+dotnet publish ./src/Website/Website.csproj --output $artifacts/publish --configuration $configuration || exit 1
+
+if [ $skipTests == 0 ]; then
+    dotnet test ./tests/Website.Tests/Website.Tests.csproj --output $artifacts --configuration $configuration || exit 1
+fi

--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ while :; do
     shift
 done
 
-export CLI_VERSION="2.0.0-preview2-006497"
+export CLI_VERSION="2.0.0"
 export DOTNET_INSTALL_DIR="$root/.dotnetcli"
 export PATH="$DOTNET_INSTALL_DIR:$PATH"
 

--- a/build.sh
+++ b/build.sh
@@ -35,14 +35,14 @@ while :; do
     shift
 done
 
-export CLI_VERSION="2.0.0-preview2-006120"
+export CLI_VERSION="2.0.0-preview2-006497"
 export DOTNET_INSTALL_DIR="$root/.dotnetcli"
 export PATH="$DOTNET_INSTALL_DIR:$PATH"
 
 dotnet_version=$(dotnet --version)
 
 if [ "$dotnet_version" != "$CLI_VERSION" ]; then
-    curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
+    curl -sSL https://raw.githubusercontent.com/dotnet/cli/release/2.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
 fi
 
 if [ $restorePackages == 1 ]; then

--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ while :; do
     shift
 done
 
-export CLI_VERSION="2.0.0-preview1-005977"
+export CLI_VERSION="2.0.0-preview2-006120"
 export DOTNET_INSTALL_DIR="$root/.dotnetcli"
 export PATH="$DOTNET_INSTALL_DIR:$PATH"
 

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 ﻿{
   "sdk": {
-    "version": "2.0.0-preview2-006120"
+    "version": "2.0.0-preview2-006497"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 ﻿{
   "sdk": {
-    "version": "2.0.0-preview1-005977"
+    "version": "2.0.0-preview2-006120"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 ﻿{
   "sdk": {
-    "version": "1.0.4"
+    "version": "2.0.0-preview1-005977"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 ﻿{
   "sdk": {
-    "version": "2.0.0-preview2-006497"
+    "version": "2.0.0"
   }
 }

--- a/src/Website/.vscode/launch.json
+++ b/src/Website/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "build",
-      "program": "${workspaceRoot}/bin/Debug/netcoreapp1.1/Website.dll",
+      "program": "${workspaceRoot}/bin/Debug/netcoreapp2.0/Website.dll",
       "args": [],
       "env": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/Website/Program.cs
+++ b/src/Website/Program.cs
@@ -1,15 +1,12 @@
-﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Copyright (c) Martin Costello, 2016. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.Website
 {
     using System;
-    using System.IO;
-    using System.Threading;
     using Extensions;
+    using Microsoft.AspNetCore;
     using Microsoft.AspNetCore.Hosting;
-    using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.Logging;
 
     /// <summary>
     /// A class representing the entry-point to the application. This class cannot be inherited.
@@ -23,55 +20,13 @@ namespace MartinCostello.Website
         /// <returns>
         /// The exit code from the application.
         /// </returns>
-        public static int Main(string[] args) => Run(args);
-
-        /// <summary>
-        /// Runs ths application.
-        /// </summary>
-        /// <param name="args">The arguments to the application.</param>
-        /// <param name="cancellationToken">The optional cancellation token to use.</param>
-        /// <returns>
-        /// The exit code from the application.
-        /// </returns>
-        public static int Run(string[] args, CancellationToken cancellationToken = default(CancellationToken))
+        public static int Main(string[] args)
         {
             try
             {
-                var configuration = new ConfigurationBuilder()
-                    .AddEnvironmentVariables()
-                    .AddCommandLine(args)
-                    .Build();
-
-                var builder = new WebHostBuilder()
-                    .UseKestrel((p) => p.AddServerHeader = false)
-                    .UseAzureAppServices()
-                    .UseAutofac()
-                    .UseConfiguration(configuration)
-                    .UseContentRoot(Directory.GetCurrentDirectory())
-                    .UseIISIntegration()
-                    .ConfigureLogging(
-                        (hostingContext, factory) =>
-                        {
-                            if (hostingContext.HostingEnvironment.IsDevelopment())
-                            {
-                                factory.AddDebug();
-                            }
-                        })
-                    .UseStartup<Startup>()
-                    .CaptureStartupErrors(true);
-
-                using (var host = builder.Build())
+                using (var host = BuildWebHost(args))
                 {
-                    using (var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
-                    {
-                        Console.CancelKeyPress += (_, e) =>
-                        {
-                            tokenSource.Cancel();
-                            e.Cancel = true;
-                        };
-
-                        host.RunAsync(tokenSource.Token).GetAwaiter().GetResult();
-                    }
+                    host.Run();
                 }
 
                 return 0;
@@ -81,6 +36,17 @@ namespace MartinCostello.Website
                 Console.Error.WriteLine($"Unhandled exception: {ex}");
                 return -1;
             }
+        }
+
+        private static IWebHost BuildWebHost(string[] args)
+        {
+            return WebHost.CreateDefaultBuilder(args)
+                .UseKestrel((p) => p.AddServerHeader = false)
+                .UseAutofac()
+                .UseAzureAppServices()
+                .UseStartup<Startup>()
+                .CaptureStartupErrors(true)
+                .Build();
         }
     }
 }

--- a/src/Website/Program.cs
+++ b/src/Website/Program.cs
@@ -49,7 +49,15 @@ namespace MartinCostello.Website
                     .UseConfiguration(configuration)
                     .UseContentRoot(Directory.GetCurrentDirectory())
                     .UseIISIntegration()
-                    .UseLoggerFactory(new LoggerFactory(configuration))
+                    .UseLoggerFactory(new LoggerFactory())
+                    .ConfigureLogging<LoggerFactory>(
+                        (hostingContext, factory) =>
+                        {
+                            if (hostingContext.HostingEnvironment.IsDevelopment())
+                            {
+                                factory.AddDebug();
+                            }
+                        })
                     .UseStartup<Startup>()
                     .CaptureStartupErrors(true);
 

--- a/src/Website/Program.cs
+++ b/src/Website/Program.cs
@@ -49,8 +49,7 @@ namespace MartinCostello.Website
                     .UseConfiguration(configuration)
                     .UseContentRoot(Directory.GetCurrentDirectory())
                     .UseIISIntegration()
-                    .UseLoggerFactory(new LoggerFactory())
-                    .ConfigureLogging<LoggerFactory>(
+                    .ConfigureLogging(
                         (hostingContext, factory) =>
                         {
                             if (hostingContext.HostingEnvironment.IsDevelopment())

--- a/src/Website/Program.cs
+++ b/src/Website/Program.cs
@@ -9,6 +9,7 @@ namespace MartinCostello.Website
     using Extensions;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
 
     /// <summary>
     /// A class representing the entry-point to the application. This class cannot be inherited.
@@ -48,6 +49,7 @@ namespace MartinCostello.Website
                     .UseConfiguration(configuration)
                     .UseContentRoot(Directory.GetCurrentDirectory())
                     .UseIISIntegration()
+                    .UseLoggerFactory(new LoggerFactory(configuration))
                     .UseStartup<Startup>()
                     .CaptureStartupErrors(true);
 

--- a/src/Website/Program.cs
+++ b/src/Website/Program.cs
@@ -61,7 +61,7 @@ namespace MartinCostello.Website
                             e.Cancel = true;
                         };
 
-                        host.Run(tokenSource.Token);
+                        host.RunAsync(tokenSource.Token).GetAwaiter().GetResult();
                     }
                 }
 

--- a/src/Website/StartupBase.cs
+++ b/src/Website/StartupBase.cs
@@ -65,22 +65,17 @@ namespace MartinCostello.Website
         /// <param name="app">The <see cref="IApplicationBuilder"/> to use.</param>
         /// <param name="environment">The <see cref="IHostingEnvironment"/> to use.</param>
         /// <param name="appLifetime">The <see cref="IApplicationLifetime"/> to use.</param>
-        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use.</param>
+        /// <param name="loggerFactory">The <see cref="LoggerFactory"/> to use.</param>
         /// <param name="options">The snapshot of <see cref="SiteOptions"/> to use.</param>
         public void Configure(
             IApplicationBuilder app,
             IHostingEnvironment environment,
             IApplicationLifetime appLifetime,
-            ILoggerFactory loggerFactory,
+            LoggerFactory loggerFactory,
             IOptionsSnapshot<SiteOptions> options)
         {
             loggerFactory.AddSerilog();
             appLifetime.ApplicationStopped.Register(Log.CloseAndFlush);
-
-            if (environment.IsDevelopment())
-            {
-                loggerFactory.AddDebug();
-            }
 
             app.UseCustomHttpHeaders(environment, Configuration, options);
 

--- a/src/Website/StartupBase.cs
+++ b/src/Website/StartupBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Copyright (c) Martin Costello, 2016. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.Website
@@ -139,10 +139,11 @@ namespace MartinCostello.Website
             services.AddAntiforgery(
                 (p) =>
                 {
-                    p.CookieName = "_anti-forgery";
+                    p.Cookie.HttpOnly = true;
+                    p.Cookie.Name = "_anti-forgery";
+                    p.Cookie.SecurePolicy = CookiePolicy();
                     p.FormFieldName = "_anti-forgery";
                     p.HeaderName = "x-anti-forgery";
-                    p.RequireSsl = !HostingEnvironment.IsDevelopment();
                 });
 
             services
@@ -256,6 +257,12 @@ namespace MartinCostello.Website
             };
         }
 
+        /// <summary>
+        /// Creates the <see cref="CookieSecurePolicy"/> to use.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="CookieSecurePolicy"/> to use for the application.
+        /// </returns>
         private CookieSecurePolicy CookiePolicy()
         {
             return HostingEnvironment.IsDevelopment() ? CookieSecurePolicy.SameAsRequest : CookieSecurePolicy.Always;

--- a/src/Website/StartupBase.cs
+++ b/src/Website/StartupBase.cs
@@ -65,13 +65,13 @@ namespace MartinCostello.Website
         /// <param name="app">The <see cref="IApplicationBuilder"/> to use.</param>
         /// <param name="environment">The <see cref="IHostingEnvironment"/> to use.</param>
         /// <param name="appLifetime">The <see cref="IApplicationLifetime"/> to use.</param>
-        /// <param name="loggerFactory">The <see cref="LoggerFactory"/> to use.</param>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="options">The snapshot of <see cref="SiteOptions"/> to use.</param>
         public void Configure(
             IApplicationBuilder app,
             IHostingEnvironment environment,
             IApplicationLifetime appLifetime,
-            LoggerFactory loggerFactory,
+            ILoggerFactory loggerFactory,
             IOptionsSnapshot<SiteOptions> options)
         {
             loggerFactory.AddSerilog();
@@ -81,8 +81,6 @@ namespace MartinCostello.Website
 
             if (environment.IsDevelopment())
             {
-                loggerFactory.AddDebug();
-
                 app.UseDeveloperExceptionPage();
             }
             else

--- a/src/Website/Views/Shared/_Layout.cshtml
+++ b/src/Website/Views/Shared/_Layout.cshtml
@@ -1,4 +1,4 @@
-﻿@inject IConfiguration Config
+@inject IConfiguration Config
 <!DOCTYPE html>
 <html lang="en-gb">
 <head prefix="og:http://ogp.me/ns#">
@@ -25,7 +25,6 @@
     @await RenderSectionAsync("meta", required: false)
     @await Html.PartialAsync("_StylesHead")
     @await RenderSectionAsync("stylesHead", required: false)
-    @Html.Raw(JavaScriptSnippet.FullScript)
     <script type="text/javascript">
         if (self == top) {
             document.documentElement.className = document.documentElement.className.replace(/\bjs-flash\b/, '');

--- a/src/Website/Views/_ViewImports.cshtml
+++ b/src/Website/Views/_ViewImports.cshtml
@@ -1,4 +1,4 @@
-﻿@using System.Globalization
+@using System.Globalization
 @using Microsoft.Extensions.Configuration
 @using MartinCostello.Website
 @using MartinCostello.Website.Extensions
@@ -6,5 +6,4 @@
 @using MartinCostello.Website.Options
 @addTagHelper "*, Microsoft.AspNetCore.Mvc.TagHelpers"
 @addTagHelper "*, Website"
-@inject Microsoft.ApplicationInsights.AspNetCore.JavaScriptSnippet JavaScriptSnippet
 @inject SiteOptions Options

--- a/src/Website/Website.csproj
+++ b/src/Website/Website.csproj
@@ -22,18 +22,13 @@
     <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.4.337" />
     <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.1.2" />
     <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.1.2" />
-    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="1.0.1" />
+    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.5.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="2.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink.Loader" Version="14.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NodaTime" Version="2.0.2" />
     <PackageReference Include="Serilog" Version="2.4.0" />

--- a/src/Website/Website.csproj
+++ b/src/Website/Website.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <DebugType>full</DebugType>
     <Description>https://martincostello.com/</Description>
+    <MvcRazorCompileOnPublish>false</MvcRazorCompileOnPublish>
     <OutputType>Exe</OutputType>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RootNamespace>MartinCostello.Website</RootNamespace>
@@ -34,7 +35,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="2.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink.Loader" Version="14.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NodaTime" Version="2.0.2" />
     <PackageReference Include="Serilog" Version="2.4.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="1.4.0" />

--- a/src/Website/Website.csproj
+++ b/src/Website/Website.csproj
@@ -8,7 +8,7 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RootNamespace>MartinCostello.Website</RootNamespace>
     <Summary>Martin Costello's website</Summary>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <UserSecretsId>martincostello.com</UserSecretsId>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -28,23 +28,15 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.5.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.1.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.CookiePolicy" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.HttpOverrides" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.ResponseCaching" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.ResponseCompression" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="1.1.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.0-beta5" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="2.0.0-preview1-final" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink.Loader" Version="14.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
-    <PackageReference Include="NodaTime" Version="2.0.1" />
+    <PackageReference Include="NodaTime" Version="2.0.2" />
     <PackageReference Include="Serilog" Version="2.4.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="1.4.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.3.1" />
@@ -52,8 +44,8 @@
     <PackageReference Include="Serilog.Sinks.Literate" Version="2.1.0" />
     <PackageReference Include="Serilog.Sinks.UDP" Version="2.3.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.0-beta-25022-02" />
-    <PackageReference Include="WindowsAzure.Storage" Version="8.1.1" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.0-preview2-25330-01" />
+    <PackageReference Include="WindowsAzure.Storage" Version="8.1.4" />
   </ItemGroup>
   <Target Name="BundleAssets" BeforeTargets="PrepareForPublish">
     <Exec Command="npm install --loglevel=error" Condition=" '$(InstallWebPackages)' == 'true' " />

--- a/src/Website/Website.csproj
+++ b/src/Website/Website.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.0-beta5" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="2.0.0-preview1-final" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.0-preview1-final" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0-preview1-final" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0-preview1-final" />

--- a/src/Website/Website.csproj
+++ b/src/Website/Website.csproj
@@ -23,11 +23,11 @@
     <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.1.2" />
     <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.1.2" />
     <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0" />
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.5.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.1.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NodaTime" Version="2.0.2" />

--- a/src/Website/Website.csproj
+++ b/src/Website/Website.csproj
@@ -27,13 +27,12 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.5.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.1.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.0-beta6" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="2.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink.Loader" Version="14.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="NodaTime" Version="2.0.2" />
@@ -44,7 +43,6 @@
     <PackageReference Include="Serilog.Sinks.Literate" Version="2.1.0" />
     <PackageReference Include="Serilog.Sinks.UDP" Version="2.3.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.1.4" />
   </ItemGroup>
   <Target Name="BundleAssets" BeforeTargets="PrepareForPublish">

--- a/src/Website/Website.csproj
+++ b/src/Website/Website.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <DebugType>full</DebugType>
     <Description>https://martincostello.com/</Description>
-    <MvcRazorCompileOnPublish>false</MvcRazorCompileOnPublish>
     <OutputType>Exe</OutputType>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RootNamespace>MartinCostello.Website</RootNamespace>
@@ -53,7 +52,7 @@
   <Target Name="PrepublishScript" DependsOnTargets="BundleAssets" BeforeTargets="Publish">
     <Exec Command="gulp publish" />
   </Target>
-  <Target Name="AddGeneratedContentItems" BeforeTargets="AssignTargetPaths" DependsOnTargets="PrepareForPublish">
+  <Target Name="AddGeneratedContentItems" BeforeTargets="AssignTargetPaths">
     <ItemGroup>
       <Content Include="wwwroot/**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Content)" />
     </ItemGroup>

--- a/src/Website/Website.csproj
+++ b/src/Website/Website.csproj
@@ -4,7 +4,6 @@
     <DebugType>full</DebugType>
     <Description>https://martincostello.com/</Description>
     <OutputType>Exe</OutputType>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RootNamespace>MartinCostello.Website</RootNamespace>
     <Summary>Martin Costello's website</Summary>

--- a/src/Website/Website.csproj
+++ b/src/Website/Website.csproj
@@ -27,13 +27,13 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.5.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.1.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.0-beta5" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview1-final" />
-    <PackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="2.0.0-preview1-final" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.0-preview1-final" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0-preview1-final" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0-preview1-final" />
-    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.0-beta6" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="2.0.0-preview2-final" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink.Loader" Version="14.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="NodaTime" Version="2.0.2" />
@@ -44,7 +44,7 @@
     <PackageReference Include="Serilog.Sinks.Literate" Version="2.1.0" />
     <PackageReference Include="Serilog.Sinks.UDP" Version="2.3.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.0-preview2-25330-01" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.1.4" />
   </ItemGroup>
   <Target Name="BundleAssets" BeforeTargets="PrepareForPublish">

--- a/tests/Website.Tests/Integration/HttpServerFixture.cs
+++ b/tests/Website.Tests/Integration/HttpServerFixture.cs
@@ -44,8 +44,7 @@ namespace MartinCostello.Website.Integration
             var builder = new WebHostBuilder()
                 .UseContentRoot(projectPath)
                 .UseEnvironment("Development")
-                .UseLoggerFactory(new LoggerFactory())
-                .ConfigureLogging<LoggerFactory>((p) => p.AddDebug())
+                .ConfigureLogging((p) => p.AddDebug())
                 .UseStartup<TestStartup>();
 
             _server = new TestServer(builder);

--- a/tests/Website.Tests/Integration/HttpServerFixture.cs
+++ b/tests/Website.Tests/Integration/HttpServerFixture.cs
@@ -45,6 +45,12 @@ namespace MartinCostello.Website.Integration
                 .UseContentRoot(projectPath)
                 .UseEnvironment("Development")
                 .UseLoggerFactory(new LoggerFactory())
+                .ConfigureLogging<LoggerFactory>(
+                    (hostingContext, factory) =>
+                    {
+                        factory.AddDebug();
+                        factory.AddConsole(hostingContext.Configuration);
+                    })
                 .UseStartup<TestStartup>();
 
             _server = new TestServer(builder);

--- a/tests/Website.Tests/Integration/HttpServerFixture.cs
+++ b/tests/Website.Tests/Integration/HttpServerFixture.cs
@@ -45,12 +45,7 @@ namespace MartinCostello.Website.Integration
                 .UseContentRoot(projectPath)
                 .UseEnvironment("Development")
                 .UseLoggerFactory(new LoggerFactory())
-                .ConfigureLogging<LoggerFactory>(
-                    (hostingContext, factory) =>
-                    {
-                        factory.AddDebug();
-                        factory.AddConsole(hostingContext.Configuration);
-                    })
+                .ConfigureLogging<LoggerFactory>((p) => p.AddDebug())
                 .UseStartup<TestStartup>();
 
             _server = new TestServer(builder);

--- a/tests/Website.Tests/Integration/HttpServerFixture.cs
+++ b/tests/Website.Tests/Integration/HttpServerFixture.cs
@@ -9,6 +9,7 @@ namespace MartinCostello.Website.Integration
     using System.Reflection;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.TestHost;
+    using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.PlatformAbstractions;
 
     /// <summary>
@@ -43,6 +44,7 @@ namespace MartinCostello.Website.Integration
             var builder = new WebHostBuilder()
                 .UseContentRoot(projectPath)
                 .UseEnvironment("Development")
+                .UseLoggerFactory(new LoggerFactory())
                 .UseStartup<TestStartup>();
 
             _server = new TestServer(builder);

--- a/tests/Website.Tests/Website.Tests.csproj
+++ b/tests/Website.Tests/Website.Tests.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\..\src\Website\Website.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0-preview2-final" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="NodaTime.Testing" Version="2.0.2" />
     <PackageReference Include="OpenCover" Version="4.6.519" />

--- a/tests/Website.Tests/Website.Tests.csproj
+++ b/tests/Website.Tests/Website.Tests.csproj
@@ -15,8 +15,8 @@
     <ProjectReference Include="..\..\src\Website\Website.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NodaTime.Testing" Version="2.0.2" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="Shouldly" Version="2.8.2" />

--- a/tests/Website.Tests/Website.Tests.csproj
+++ b/tests/Website.Tests/Website.Tests.csproj
@@ -5,7 +5,7 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RootNamespace>MartinCostello.Website</RootNamespace>
     <Summary>Tests for Martin Costello's website</Summary>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyVersion.cs;..\..\CommonAssemblyInfo.cs" />
@@ -15,9 +15,9 @@
     <ProjectReference Include="..\..\src\Website\Website.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0-preview1-final" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="NodaTime.Testing" Version="2.0.1" />
+    <PackageReference Include="NodaTime.Testing" Version="2.0.2" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="Shouldly" Version="2.8.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="All" />


### PR DESCRIPTION
  1. Update to use .NET Core 2.0 (`preview1-005977`).
  1. Update to ASP.NET Core 2.0 (`preview1-final`).
  1. Refactor `Build.ps1` to be more efficient and improve runtime installation.
  1. Refactor `build.sh` to be functionally equivalent to `Build.ps1`.
  1. Update to NodaTime `2.0.2`.
  1. Remove redundant environment variables.
  1. Remove redundant NuGet feed.

For reasons unknown, `dotnet restore` fails for the test project due to something in the main project on Windows.