### PR TITLE
Add nofollow to link tags on tools page

### DIFF
--- a/src/Website/Assets/Scripts/ts/martinCostello/website/tools/GuidGenerator.ts
+++ b/src/Website/Assets/Scripts/ts/martinCostello/website/tools/GuidGenerator.ts
@@ -24,7 +24,7 @@ namespace martinCostello.website.tools {
          */
         public initialize(): void {
 
-            this.endpoint = $("link[rel='api-guid']").attr("href");
+            this.endpoint = $("link[name='api-guid']").attr("href");
 
             if (this.endpoint) {
 

--- a/src/Website/Assets/Scripts/ts/martinCostello/website/tools/HashGenerator.ts
+++ b/src/Website/Assets/Scripts/ts/martinCostello/website/tools/HashGenerator.ts
@@ -26,7 +26,7 @@ namespace martinCostello.website.tools {
          */
         public initialize(): void {
 
-            this.endpoint = $("link[rel='api-hash']").attr("href");
+            this.endpoint = $("link[name='api-hash']").attr("href");
 
             if (this.endpoint) {
 

--- a/src/Website/Assets/Scripts/ts/martinCostello/website/tools/MachineKeyGenerator.ts
+++ b/src/Website/Assets/Scripts/ts/martinCostello/website/tools/MachineKeyGenerator.ts
@@ -25,7 +25,7 @@ namespace martinCostello.website.tools {
          */
         public initialize(): void {
 
-            this.endpoint = $("link[rel='api-machine-key']").attr("href");
+            this.endpoint = $("link[name='api-machine-key']").attr("href");
 
             if (this.endpoint) {
 

--- a/src/Website/Views/Tools/Index.cshtml
+++ b/src/Website/Views/Tools/Index.cshtml
@@ -1,7 +1,7 @@
 ﻿@section meta {
-   <link rel="api-guid" href="@Url.RouteUrl(SiteRoutes.GenerateGuid)" />
-   <link rel="api-hash" href="@Url.RouteUrl(SiteRoutes.GenerateHash)" />
-   <link rel="api-machine-key" href="@Url.RouteUrl(SiteRoutes.GenerateMachineKey)" />
+   <link name="api-guid" rel="nofollow" href="@Url.RouteUrl(SiteRoutes.GenerateGuid)" />
+   <link name="api-hash" rel="nofollow" href="@Url.RouteUrl(SiteRoutes.GenerateHash)" />
+   <link name="api-machine-key" rel="nofollow" href="@Url.RouteUrl(SiteRoutes.GenerateMachineKey)" />
 }
 @section scripts {
     <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.6.1/clipboard.min.js" integrity="sha256-El0fEiD3YOM7uIVZztyQzmbbPlgEj0oJVxRWziUh4UE=" crossorigin="anonymous" defer></script>


### PR DESCRIPTION
Add a `nofollow` to the `rel` attribute of the `<link>` tags used for the API endpoints for the `/tools` page.