### PR TITLE
Fix .well-known folder not being published

### DIFF
--- a/src/Website/Website.csproj
+++ b/src/Website/Website.csproj
@@ -51,6 +51,7 @@
   <Target Name="AddGeneratedContentItems" BeforeTargets="AssignTargetPaths">
     <ItemGroup>
       <Content Include="wwwroot/**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Content)" />
+      <Content Include="wwwroot/.well-known/**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes)" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Fix the `.well-known` folder not being included by `dotnet publish` since #208.