### PR TITLE
Add Feature-Policy HTTP header

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceRoot}/src/Website/bin/Debug/netcoreapp2.0/Website.dll",
+            "program": "${workspaceRoot}/src/Website/bin/Debug/netcoreapp2.1/Website.dll",
             "args": [],
             "cwd": "${workspaceRoot}/src/Website",
             "stopAtEntry": false,

--- a/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
@@ -103,6 +103,7 @@ namespace MartinCostello.Website.Middleware
 
                     context.Response.Headers.Add("Content-Security-Policy", _contentSecurityPolicy);
                     context.Response.Headers.Add("Content-Security-Policy-Report-Only", _contentSecurityPolicyReportOnly);
+                    context.Response.Headers.Add("Feature-Policy", "accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'");
                     context.Response.Headers.Add("Referrer-Policy", "no-referrer-when-downgrade");
                     context.Response.Headers.Add("X-Content-Type-Options", "nosniff");
                     context.Response.Headers.Add("X-Download-Options", "noopen");

--- a/tests/Website.Tests/Integration/ResourceTests.cs
+++ b/tests/Website.Tests/Integration/ResourceTests.cs
@@ -116,6 +116,7 @@ namespace MartinCostello.Website.Integration
             {
                 "content-security-policy",
                 "content-security-policy-report-only",
+                "feature-policy",
                 "Referrer-Policy",
                 "X-Content-Type-Options",
                 "X-Datacenter",


### PR DESCRIPTION
Return a `Feature-Policy` HTTP response header.

Also fixes the VS Code launch configuration.