### PR TITLE
ASP.NET Core 3.0 preparation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
     <LangVersion>latest</LangVersion>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <NoWarn>$(NoWarn);CA1054;CA1056;CA1707;CA1720;CA2227;CA2234</NoWarn>
+    <NoWarn>$(NoWarn);CA1054;CA1056;CA1707;CA1720;CA2227;CA2234;MSB3030</NoWarn>
     <PackageIconUrl>https://martincostello.com/favicon.ico</PackageIconUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/martincostello/website</PackageProjectUrl>

--- a/src/Website/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/Website/Extensions/IApplicationBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Copyright (c) Martin Costello, 2016. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.Website.Extensions
@@ -29,7 +29,7 @@ namespace MartinCostello.Website.Extensions
             this IApplicationBuilder value,
             IHostingEnvironment environment,
             IConfiguration config,
-            IOptionsSnapshot<SiteOptions> options)
+            IOptions<SiteOptions> options)
         {
             return value.UseMiddleware<CustomHttpHeadersMiddleware>(environment, config, options);
         }

--- a/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
@@ -32,9 +32,9 @@ namespace MartinCostello.Website.Middleware
         private readonly IConfiguration _config;
 
         /// <summary>
-        /// The options snapshot to use. This field is read-only.
+        /// The options to use. This field is read-only.
         /// </summary>
-        private readonly IOptionsSnapshot<SiteOptions> _options;
+        private readonly IOptions<SiteOptions> _options;
 
         /// <summary>
         /// The current <c>Content-Security-Policy</c> HTTP response header value. This field is read-only.
@@ -72,7 +72,7 @@ namespace MartinCostello.Website.Middleware
             RequestDelegate next,
             IHostingEnvironment environment,
             IConfiguration config,
-            IOptionsSnapshot<SiteOptions> options)
+            IOptions<SiteOptions> options)
         {
             _next = next;
             _config = config;

--- a/src/Website/Services/ToolsService.cs
+++ b/src/Website/Services/ToolsService.cs
@@ -14,6 +14,7 @@ namespace MartinCostello.Website.Services
     using Api.Models;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Options;
     using Options;
 
     /// <summary>
@@ -53,12 +54,12 @@ namespace MartinCostello.Website.Services
         /// <summary>
         /// Initializes a new instance of the <see cref="ToolsService"/> class.
         /// </summary>
-        /// <param name="context">The current HTTP context.</param>
+        /// <param name="contextAccessor">The <see cref="IHttpContextAccessor"/> to use.</param>
         /// <param name="options">The site options to use.</param>
-        public ToolsService(HttpContext context, SiteOptions options)
+        public ToolsService(IHttpContextAccessor contextAccessor, IOptions<SiteOptions> options)
         {
-            _apiUri = options?.ExternalLinks?.Api;
-            _traceId = context.TraceIdentifier;
+            _apiUri = options?.Value?.ExternalLinks?.Api;
+            _traceId = contextAccessor.HttpContext.TraceIdentifier;
         }
 
         /// <inheritdoc/>

--- a/tests/Website.Tests/Integration/HttpServerFixture.cs
+++ b/tests/Website.Tests/Integration/HttpServerFixture.cs
@@ -9,7 +9,6 @@ namespace MartinCostello.Website.Integration
     using System.Net.Sockets;
     using System.Security.Cryptography.X509Certificates;
     using Microsoft.AspNetCore.Hosting;
-    using Microsoft.AspNetCore.TestHost;
 
     /// <summary>
     /// A test fixture representing an HTTP server hosting the application. This class cannot be inherited.
@@ -28,7 +27,6 @@ namespace MartinCostello.Website.Integration
             ClientOptions.BaseAddress = FindFreeServerAddress();
 
             var builder = CreateWebHostBuilder()
-                .UseSolutionRelativeContentRoot("src/Website")
                 .UseUrls(ClientOptions.BaseAddress.ToString())
                 .UseKestrel(
                     (p) => p.ConfigureHttpsDefaults(

--- a/tests/Website.Tests/Integration/HttpServerFixture.cs
+++ b/tests/Website.Tests/Integration/HttpServerFixture.cs
@@ -8,11 +8,8 @@ namespace MartinCostello.Website.Integration
     using System.Net.Http;
     using System.Net.Sockets;
     using System.Security.Cryptography.X509Certificates;
-    using MartinCostello.Logging.XUnit;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.TestHost;
-    using Microsoft.Extensions.DependencyInjection;
-    using Xunit.Abstractions;
 
     /// <summary>
     /// A test fixture representing an HTTP server hosting the application. This class cannot be inherited.
@@ -48,6 +45,9 @@ namespace MartinCostello.Website.Integration
         /// </summary>
         public Uri ServerAddress => ClientOptions.BaseAddress;
 
+        /// <inheritdoc />
+        public override IServiceProvider Services => _webHost?.Services;
+
         /// <summary>
         /// Creates an <see cref="HttpClient"/> to communicate with the application.
         /// </summary>
@@ -77,14 +77,6 @@ namespace MartinCostello.Website.Integration
 
             return client;
         }
-
-        /// <inheritdoc />
-        public override void ClearOutputHelper()
-            => _webHost.Services.GetRequiredService<ITestOutputHelperAccessor>().OutputHelper = null;
-
-        /// <inheritdoc />
-        public override void SetOutputHelper(ITestOutputHelper value)
-            => _webHost.Services.GetRequiredService<ITestOutputHelperAccessor>().OutputHelper = value;
 
         /// <inheritdoc />
         protected override void Dispose(bool disposing)

--- a/tests/Website.Tests/Integration/TestServerFixture.cs
+++ b/tests/Website.Tests/Integration/TestServerFixture.cs
@@ -27,24 +27,34 @@ namespace MartinCostello.Website.Integration
             ClientOptions.AllowAutoRedirect = false;
             ClientOptions.BaseAddress = new Uri("https://localhost");
 
-            // HACK Force HTTP server startup
-            using (CreateDefaultClient())
-            {
-            }
+            EnsureStarted();
         }
+
+        /// <summary>
+        /// Gets the <see cref="IServiceProvider"/> in use.
+        /// </summary>
+        public virtual IServiceProvider Services => Server?.Host?.Services;
 
         /// <summary>
         /// Clears the current <see cref="ITestOutputHelper"/>.
         /// </summary>
         public virtual void ClearOutputHelper()
-            => Server.Host.Services.GetRequiredService<ITestOutputHelperAccessor>().OutputHelper = null;
+        {
+            if (Services != null)
+            {
+                Services.GetRequiredService<ITestOutputHelperAccessor>().OutputHelper = null;
+            }
+        }
 
         /// <summary>
         /// Sets the <see cref="ITestOutputHelper"/> to use.
         /// </summary>
         /// <param name="value">The <see cref="ITestOutputHelper"/> to use.</param>
         public virtual void SetOutputHelper(ITestOutputHelper value)
-            => Server.Host.Services.GetRequiredService<ITestOutputHelperAccessor>().OutputHelper = value;
+        {
+            EnsureStarted();
+            Services.GetRequiredService<ITestOutputHelperAccessor>().OutputHelper = value;
+        }
 
         /// <inheritdoc />
         protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -65,6 +75,14 @@ namespace MartinCostello.Website.Integration
             builder.AddJsonFile("appsettings.json")
                    .AddJsonFile(fullPath)
                    .AddEnvironmentVariables();
+        }
+
+        private void EnsureStarted()
+        {
+            // HACK Force HTTP server startup
+            using (CreateDefaultClient())
+            {
+            }
         }
     }
 }

--- a/tests/Website.Tests/Integration/TestServerFixture.cs
+++ b/tests/Website.Tests/Integration/TestServerFixture.cs
@@ -5,6 +5,8 @@ namespace MartinCostello.Website.Integration
 {
     using System;
     using System.IO;
+    using System.Linq;
+    using System.Reflection;
     using MartinCostello.Logging.XUnit;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Mvc.Testing;
@@ -60,7 +62,25 @@ namespace MartinCostello.Website.Integration
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
             builder.ConfigureAppConfiguration(ConfigureTests)
-                   .ConfigureLogging((loggingBuilder) => loggingBuilder.ClearProviders().AddXUnit());
+                   .ConfigureLogging((loggingBuilder) => loggingBuilder.ClearProviders().AddXUnit())
+                   .UseContentRoot(GetApplicationContentRootPath());
+        }
+
+        /// <summary>
+        /// Gets the content root path to use for the application.
+        /// </summary>
+        /// <returns>
+        /// The content root path to use for the application.
+        /// </returns>
+        protected string GetApplicationContentRootPath()
+        {
+            var attribute = GetTestAssemblies()
+                .SelectMany((p) => p.GetCustomAttributes<WebApplicationFactoryContentRootAttribute>())
+                .Where((p) => string.Equals(p.Key, "Website", StringComparison.OrdinalIgnoreCase))
+                .OrderBy((p) => p.Priority)
+                .First();
+
+            return attribute.ContentRootPath;
         }
 
         private static void ConfigureTests(IConfigurationBuilder builder)

--- a/tests/Website.Tests/Website.Tests.csproj
+++ b/tests/Website.Tests/Website.Tests.csproj
@@ -13,6 +13,12 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Website\Website.csproj" />
+    <WebApplicationFactoryContentRootAttribute
+      Include="Website"
+      AssemblyName="Website"
+      ContentRootPath="$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../../src/Website'))"
+      ContentRootTest="Website.csproj"
+      Priority="-1" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0" />


### PR DESCRIPTION
  * Refactor usage of `IServiceProvider` in `Startup` to prepare for ASP.NET Core 3.0 changes.
  * Refactor usage of `WebApplicationFactory<T>` to expose the `IServiceProvider` via a property that abstracts whether a real host or a `TestServer` host is in use.
  * Use the `WebApplicationFactoryContentRootAttribute` MSBuild item to configure the content root directory.