### PR TITLE
Refactor WebApplicationFactory<T> usage

### DIFF
--- a/tests/Website.Tests/Integration/HttpServerFixture.cs
+++ b/tests/Website.Tests/Integration/HttpServerFixture.cs
@@ -8,14 +8,16 @@ namespace MartinCostello.Website.Integration
     using System.Net.Http;
     using System.Net.Sockets;
     using System.Security.Cryptography.X509Certificates;
+    using System.Threading.Tasks;
     using Microsoft.AspNetCore.Hosting;
+    using Xunit;
 
     /// <summary>
     /// A test fixture representing an HTTP server hosting the application. This class cannot be inherited.
     /// </summary>
-    public sealed class HttpServerFixture : TestServerFixture
+    public sealed class HttpServerFixture : TestServerFixture, IAsyncLifetime
     {
-        private readonly IWebHost _webHost;
+        private IWebHost _host;
         private bool _disposed;
 
         /// <summary>
@@ -24,18 +26,6 @@ namespace MartinCostello.Website.Integration
         public HttpServerFixture()
             : base()
         {
-            ClientOptions.BaseAddress = FindFreeServerAddress();
-
-            var builder = CreateWebHostBuilder()
-                .UseUrls(ClientOptions.BaseAddress.ToString())
-                .UseKestrel(
-                    (p) => p.ConfigureHttpsDefaults(
-                        (r) => r.ServerCertificate = new X509Certificate2("localhost-dev.pfx", "Pa55w0rd!")));
-
-            ConfigureWebHost(builder);
-
-            _webHost = builder.Build();
-            _webHost.Start();
         }
 
         /// <summary>
@@ -44,7 +34,19 @@ namespace MartinCostello.Website.Integration
         public Uri ServerAddress => ClientOptions.BaseAddress;
 
         /// <inheritdoc />
-        public override IServiceProvider Services => _webHost?.Services;
+        public override IServiceProvider Services => _host?.Services;
+
+        /// <inheritdoc />
+        async Task IAsyncLifetime.InitializeAsync()
+            => await EnsureHttpServerAsync();
+
+        /// <inheritdoc />
+        async Task IAsyncLifetime.DisposeAsync()
+        {
+            await _host?.StopAsync(default);
+            _host?.Dispose();
+            _host = null;
+        }
 
         /// <summary>
         /// Creates an <see cref="HttpClient"/> to communicate with the application.
@@ -77,6 +79,18 @@ namespace MartinCostello.Website.Integration
         }
 
         /// <inheritdoc />
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            base.ConfigureWebHost(builder);
+
+            builder.ConfigureKestrel(
+                (p) => p.ConfigureHttpsDefaults(
+                    (r) => r.ServerCertificate = new X509Certificate2("localhost-dev.pfx", "Pa55w0rd!")));
+
+            builder.UseUrls(ServerAddress.ToString());
+        }
+
+        /// <inheritdoc />
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
@@ -85,7 +99,7 @@ namespace MartinCostello.Website.Integration
             {
                 if (disposing)
                 {
-                    _webHost?.Dispose();
+                    _host?.Dispose();
                 }
 
                 _disposed = true;
@@ -117,6 +131,27 @@ namespace MartinCostello.Website.Integration
             {
                 listener.Stop();
             }
+        }
+
+        private async Task EnsureHttpServerAsync()
+        {
+            if (_host == null)
+            {
+                await CreateHttpServer();
+            }
+        }
+
+        private async Task CreateHttpServer()
+        {
+            // Configure the server address for the server to listen on for HTTP requests
+            ClientOptions.BaseAddress = FindFreeServerAddress();
+
+            var builder = CreateWebHostBuilder();
+
+            ConfigureWebHost(builder);
+
+            _host = builder.Build();
+            await _host.StartAsync();
         }
     }
 }

--- a/tests/Website.Tests/Integration/UI/BrowserTest.cs
+++ b/tests/Website.Tests/Integration/UI/BrowserTest.cs
@@ -195,11 +195,8 @@ namespace MartinCostello.Website.Integration.UI
                 catch (Exception)
                 {
                     TakeScreenshot(navigator.Driver, testName);
-                    throw;
-                }
-                finally
-                {
                     OutputLogs(navigator.Driver);
+                    throw;
                 }
             }
         }


### PR DESCRIPTION
  * Refactor `WebApplication<T>` usage ahead of ASP.NET Core 3.0.
  * Only emit browser logs to xunit if a test fails.