### PR TITLE
Simplify dependencies

### DIFF
--- a/src/Website/Program.cs
+++ b/src/Website/Program.cs
@@ -5,7 +5,6 @@ namespace MartinCostello.Website
 {
     using System;
     using Extensions;
-    using Microsoft.AspNetCore;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
@@ -38,6 +37,13 @@ namespace MartinCostello.Website
             }
         }
 
+        /// <summary>
+        /// Creates the <see cref="IHostBuilder"/> for the application.
+        /// </summary>
+        /// <param name="args">The arguments to the application.</param>
+        /// <returns>
+        /// The <see cref="IHostBuilder"/> to use for the application.
+        /// </returns>
         public static IHostBuilder CreateHostBuilder(string[] args)
         {
             return Host.CreateDefaultBuilder(args)
@@ -47,8 +53,6 @@ namespace MartinCostello.Website
                     {
                         webBuilder.CaptureStartupErrors(true)
                                   .ConfigureAppConfiguration((context, builder) => builder.AddApplicationInsightsSettings(developerMode: context.HostingEnvironment.IsDevelopment()))
-                                  .UseApplicationInsights()
-                                  .UseAzureAppServices()
                                   .UseStartup<Startup>();
                     });
         }

--- a/src/Website/Website.csproj
+++ b/src/Website/Website.csproj
@@ -15,9 +15,8 @@
     <Content Update="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.11.1" />
-    <PackageReference Include="Microsoft.AspNetCore.ApplicationInsights.HostingStartup" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="3.0.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.8.2" />
+    <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="3.0.0" />
     <PackageReference Include="NodaTime" Version="$(NodaTimeVersion)" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />

--- a/src/Website/Website.csproj
+++ b/src/Website/Website.csproj
@@ -24,7 +24,6 @@
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.0.4" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.UDP" Version="6.0.0" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>
   <Target Name="BundleAssets" BeforeTargets="PrepareForPublish">
     <Exec Command="npm ci" Condition=" '$(InstallWebPackages)' == 'true' " />


### PR DESCRIPTION
  * Use Microsoft.AspNetCore.AzureAppServices.HostingStartup instead of Microsoft.AspNetCore.AzureAppServicesIntegration so it is automatically enabled.
  * Use Microsoft.ApplicationInsights.AspNetCore instead of Microsoft.ApplicationInsights.DependencyCollector.
  * Remove redundant reference to the WindowsAzure.Storage NuGet package back from when the website managed the fish feeding rota.