### PR TITLE
.NET 5 preparation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{csproj,json,props,ruleset,targets,yml}]
+[*.{csproj,json,props,ruleset,targets,vsconfig,yml}]
 indent_size = 2
 
 # Code files

--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,22 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Component.CoreEditor",
+    "Microsoft.VisualStudio.Workload.CoreEditor",
+    "Microsoft.NetCore.Component.Runtime.3.1",
+    "Microsoft.NetCore.Component.SDK",
+    "Microsoft.VisualStudio.Component.Roslyn.Compiler",
+    "Microsoft.VisualStudio.Component.Roslyn.LanguageServices",
+    "Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions",
+    "Microsoft.VisualStudio.Component.TypeScript.3.8",
+    "Microsoft.VisualStudio.Component.JavaScript.TypeScript",
+    "Microsoft.VisualStudio.Component.JavaScript.Diagnostics",
+    "Component.Microsoft.VisualStudio.RazorExtension",
+    "Microsoft.VisualStudio.Component.IISExpress",
+    "Microsoft.VisualStudio.Component.WebDeploy",
+    "Microsoft.VisualStudio.Component.Node.Tools",
+    "Microsoft.VisualStudio.Workload.Node",
+    "Component.GitHub.VisualStudio",
+    "Microsoft.VisualStudio.Component.Git"
+  ]
+}

--- a/Website.sln
+++ b/Website.sln
@@ -8,6 +8,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		.vsconfig = .vsconfig
 		build.ps1 = build.ps1
 		CommonAssemblyInfo.cs = CommonAssemblyInfo.cs
 		Directory.Build.props = Directory.Build.props

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
     "version": "3.1.201",
-    "allowPrerelease": false
+    "allowPrerelease": false,
+    "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
  * Add a `.vsconfig` file for the solution.
  * Allow roll-forward to the latest version of the SDK.
