### PR TITLE
Fix analyzer warnings

### DIFF
--- a/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
@@ -181,11 +181,11 @@ namespace MartinCostello.Website.Middleware
 
                 if (origins.Count > 0)
                 {
-                    builder.Append(" ");
+                    builder.Append(' ');
                     builder.Append(string.Join(" ", origins));
                 }
 
-                builder.Append(";");
+                builder.Append(';');
             }
 
             if (!isReport && isProduction)


### PR DESCRIPTION
Fix warnings from using version 3.3.0 of the Roslyn analyzers (see #518).