### PR TITLE
Update Content Security Policy

### DIFF
--- a/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
@@ -177,7 +177,10 @@ namespace MartinCostello.Website.Middleware
                     origins = origins.Concat(configOrigins).ToList();
                 }
 
-                origins = origins.Where((p) => !string.IsNullOrWhiteSpace(p)).ToList();
+                origins = origins
+                    .Where((p) => !string.IsNullOrWhiteSpace(p))
+                    .Distinct()
+                    .ToList();
 
                 if (origins.Count > 0)
                 {

--- a/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
@@ -146,21 +146,21 @@ namespace MartinCostello.Website.Middleware
 
             var policies = new Dictionary<string, IList<string>>()
             {
-                { "default-src", new[] { Csp.Self, Csp.Data } },
-                { "script-src", new[] { Csp.Self, Csp.Inline } },
-                { "style-src", new[] { Csp.Self, Csp.Inline } },
-                { "img-src", new[] { Csp.Self, Csp.Data, cdn } },
-                { "font-src", new[] { Csp.Self } },
-                { "connect-src", new[] { Csp.Self, GetApiOriginForContentSecurityPolicy(options) } },
-                { "media-src", new[] { Csp.None } },
-                { "object-src", Array.Empty<string>() },
-                { "child-src", new[] { Csp.Self } },
-                { "frame-ancestors", new[] { Csp.None } },
-                { "form-action", new[] { Csp.Self } },
-                { "block-all-mixed-content", Array.Empty<string>() },
-                { "base-uri", new[] { Csp.Self } },
-                { "manifest-src", new[] { Csp.Self } },
-                { "worker-src", new[] { Csp.Self } },
+                ["default-src"] = new[] { Csp.Self, Csp.Data },
+                ["script-src"] = new[] { Csp.Self, Csp.Inline },
+                ["style-src"] = new[] { Csp.Self, Csp.Inline },
+                ["img-src"] = new[] { Csp.Self, Csp.Data, cdn },
+                ["font-src"] = new[] { Csp.Self },
+                ["connect-src"] = new[] { Csp.Self, GetApiOriginForContentSecurityPolicy(options) },
+                ["media-src"] = new[] { Csp.None },
+                ["object-src"] = Array.Empty<string>(),
+                ["child-src"] = new[] { Csp.Self },
+                ["frame-ancestors"] = new[] { Csp.None },
+                ["form-action"] = new[] { Csp.Self },
+                ["block-all-mixed-content"] = Array.Empty<string>(),
+                ["base-uri"] = new[] { Csp.Self },
+                ["manifest-src"] = new[] { Csp.Self },
+                ["worker-src"] = new[] { Csp.Self },
             };
 
             var builder = new StringBuilder();

--- a/src/Website/appsettings.json
+++ b/src/Website/appsettings.json
@@ -22,7 +22,7 @@
       "default-src": [ "buttons.github.io", "stackpath.bootstrapcdn.com", "platform.twitter.com" ],
       "font-src": [ "fonts.googleapis.com", "fonts.gstatic.com", "stackpath.bootstrapcdn.com", "use.fontawesome.com" ],
       "form-action": [ "platform.twitter.com", "syndication.twitter.com" ],
-      "img-src": [ "martincostello.azureedge.net", "stackoverflow.com", "static.licdn.com", "stats.g.doubleclick.net", "syndication.twitter.com", "www.google-analytics.com" ],
+      "img-src": [ "cdn.martincostello.com", "martincostello.azureedge.net", "stackoverflow.com", "static.licdn.com", "stats.g.doubleclick.net", "syndication.twitter.com", "www.google-analytics.com" ],
       "object-src": [ "ajax.cdnjs.com" ],
       "script-src": [ "api.github.com cdnjs.cloudflare.com", "az416426.vo.msecnd.net", "buttons.github.io", "stackpath.bootstrapcdn.com", "platform.twitter.com", "www.google-analytics.com" ],
       "style-src": [ "buttons.github.io", "fonts.googleapis.com", "stackpath.bootstrapcdn.com", "use.fontawesome.com" ]


### PR DESCRIPTION
  * Add the primary CDN domain to the `img-src` list explicitly.
  * Do not duplicate the CSP origins in the case that the configured list is the same as one of the built-in defaults.
  * Use newer syntax to initialise dictionary.
