### PR TITLE
Use Personal Access Token

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -17,4 +17,4 @@ jobs:
 
     - name: Update .NET SDK
       shell: pwsh
-      run: ./update-dotnet-sdk.ps1 -Channel "3.1" -GitHubToken ${{ secrets.GITHUB_TOKEN }} -UserName "martincostello" -UserEmail "martin@martincostello.com"
+      run: ./update-dotnet-sdk.ps1 -Channel "3.1" -GitHubToken ${{ secrets.ACCESS_TOKEN }} -UserName "martincostello" -UserEmail "martin@martincostello.com"


### PR DESCRIPTION
Use a Personal Access Token instead of the built-in token so that Pull Requests start the CI workflow (see https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token).