### PR TITLE
Fix automerge for forks

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - name: automerge
         uses: "pascalgn/automerge-action@f81beb99aef41bb55ad072857d43073fba833a98"
+        if: ${{ github.repository_owner == 'martincostello' }}
         env:
           GITHUB_TOKEN: "${{ secrets.ACCESS_TOKEN }}"
           MERGE_LABELS: "automerge,!blocked"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
       run: ./build.ps1
       env:
         DOTNET_CLI_TELEMETRY_OPTOUT: true
+        DOTNET_NOLOGO: true
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
         NUGET_XMLDOC_MODE: skip
 
@@ -51,7 +52,7 @@ jobs:
       if: ${{ github.ref == 'refs/heads/main' && runner.os == 'Windows' }}
       with:
         app-name: martincostello-uksouth
-        slot-name: dev 
+        slot-name: dev
         package: './artifacts/publish'
         publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_DEV  }}
 


### PR DESCRIPTION
  * Do not run the automerge workflow for forks as they don't have access to secrets.
  * Set DOTNET_NOLOGO for the build step.
