### PR TITLE
Use azure/webapps-deploy@v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
         flags: ${{ matrix.codecov_os }}
 
     - name: 'Deploy to dev.martincostello.com'
-      uses: azure/webapps-deploy@v2.1.2
+      uses: azure/webapps-deploy@v2
       if: ${{ github.ref == 'refs/heads/main' && runner.os == 'Windows' }}
       with:
         app-name: martincostello-uksouth
@@ -57,7 +57,7 @@ jobs:
         publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_DEV  }}
 
     - name: 'Deploy to martincostello.com'
-      uses: azure/webapps-deploy@v2.1.2
+      uses: azure/webapps-deploy@v2
       if: ${{ github.ref == 'refs/heads/deploy' && runner.os == 'Windows' }}
       with:
         app-name: martincostello-uksouth


### PR DESCRIPTION
Use azure/webapps-deploy@v2 to resolve warning about use of `set-env`.
