### PR TITLE
Remove self-contained deployment

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -109,10 +109,10 @@ function DotNetPublish {
     param([string]$Project)
     $publishPath = (Join-Path $OutputPath "publish")
     if ($VersionSuffix) {
-        & $dotnet publish $Project --output $publishPath --configuration $Configuration --version-suffix "$VersionSuffix" --runtime win10-x64 --self-contained
+        & $dotnet publish $Project --output $publishPath --configuration $Configuration --version-suffix "$VersionSuffix"
     }
     else {
-        & $dotnet publish $Project --output $publishPath --configuration $Configuration --runtime win10-x64 --self-contained
+        & $dotnet publish $Project --output $publishPath --configuration $Configuration
     }
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet publish failed with exit code $LASTEXITCODE"


### PR DESCRIPTION
Remove self-contained deployment to rely on App Service Early Access Runtime instead (see [docs](https://github.com/Azure/app-service-linux-docs/blob/master/Runtime_Support/early_access.md#early-access-on-windows)).
