### PR TITLE
Move deploy to own workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 
 on:
   push:
-    branches: [ main, deploy ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:
@@ -54,12 +54,4 @@ jobs:
         app-name: martincostello-uksouth
         slot-name: dev
         package: './artifacts/publish'
-        publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_DEV  }}
-
-    - name: 'Deploy to martincostello.com'
-      uses: azure/webapps-deploy@v2
-      if: ${{ github.ref == 'refs/heads/deploy' && runner.os == 'Windows' }}
-      with:
-        app-name: martincostello-uksouth
-        package: './artifacts/publish'
-        publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_PROD  }}
+        publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_DEV }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: deploy
+
+on:
+  push:
+    branches: [ deploy ]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: windows-latest
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Setup .NET Core SDK
+      uses: actions/setup-dotnet@v1
+
+    - name: Build and Publish
+      shell: pwsh
+      run: ./build.ps1 -SkipTests
+      env:
+        DOTNET_CLI_TELEMETRY_OPTOUT: true
+        DOTNET_NOLOGO: true
+        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+        NUGET_XMLDOC_MODE: skip
+
+    - name: 'Deploy to martincostello.com'
+      uses: azure/webapps-deploy@v2
+      if: ${{ github.ref == 'refs/heads/deploy' }}
+      with:
+        app-name: martincostello-uksouth
+        package: './artifacts/publish'
+        publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_PROD }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Martin Costello's website
 
-[![Build status](https://github.com/martincostello/website/workflows/build/badge.svg?branch=main&event=push)](https://github.com/martincostello/website/actions?query=workflow%3Abuild+branch%3Amain+event%3Apush)
+[![Build status](https://github.com/martincostello/website/workflows/build/badge.svg?branch=main&event=push)](https://github.com/martincostello/website/actions?
+query=workflow%3Abuild+branch%3Amain+event%3Apush)
+
+[![Deploy status](https://github.com/martincostello/website/workflows/deploy/badge.svg?branch=deploy&event=push)](https://github.com/martincostello/website/actions?
+query=workflow%3Adeploy+branch%3Adeploy+event%3Apush)
 
 ## Overview
 


### PR DESCRIPTION
For the deploy branch, run a dedicated workflow that just builds and publishes for Windows.
