### PR TITLE
Improve port binding in tests

### DIFF
--- a/tests/Website.Tests/Integration/HttpServerFixture.cs
+++ b/tests/Website.Tests/Integration/HttpServerFixture.cs
@@ -4,12 +4,13 @@
 namespace MartinCostello.Website.Integration
 {
     using System;
-    using System.Net;
+    using System.Linq;
     using System.Net.Http;
-    using System.Net.Sockets;
     using System.Security.Cryptography.X509Certificates;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.Hosting.Server;
+    using Microsoft.AspNetCore.Hosting.Server.Features;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using Xunit;
@@ -64,19 +65,12 @@ namespace MartinCostello.Website.Integration
             var handler = new HttpClientHandler()
             {
                 AllowAutoRedirect = ClientOptions.AllowAutoRedirect,
+                CheckCertificateRevocationList = true,
                 MaxAutomaticRedirections = ClientOptions.MaxAutomaticRedirections,
                 UseCookies = ClientOptions.HandleCookies,
             };
 
-            if (ClientOptions.BaseAddress.IsLoopback &&
-                string.Equals(ClientOptions.BaseAddress.Scheme, "https", StringComparison.OrdinalIgnoreCase))
-            {
-                handler.ServerCertificateCustomValidationCallback = (request, cert, chain, errors) => true;
-            }
-
-#pragma warning disable CA5400
-            var client = new HttpClient(handler);
-#pragma warning restore CA5400
+            var client = new HttpClient(handler, disposeHandler: true);
 
             ConfigureClient(client);
 
@@ -94,7 +88,9 @@ namespace MartinCostello.Website.Integration
                 (p) => p.ConfigureHttpsDefaults(
                     (r) => r.ServerCertificate = new X509Certificate2("localhost-dev.pfx", "Pa55w0rd!")));
 
-            builder.UseUrls(ServerAddress.ToString());
+            // Configure the server address for the server to
+            // listen on for HTTPS requests on a dynamic port.
+            builder.UseUrls("https://127.0.0.1:0");
         }
 
         /// <inheritdoc />
@@ -113,33 +109,6 @@ namespace MartinCostello.Website.Integration
             }
         }
 
-        private static Uri FindFreeServerAddress()
-        {
-            int port = GetFreePortNumber();
-
-            return new UriBuilder()
-            {
-                Scheme = "https",
-                Host = "localhost",
-                Port = port,
-            }.Uri;
-        }
-
-        private static int GetFreePortNumber()
-        {
-            var listener = new TcpListener(IPAddress.Loopback, 0);
-            listener.Start();
-
-            try
-            {
-                return ((IPEndPoint)listener.LocalEndpoint).Port;
-            }
-            finally
-            {
-                listener.Stop();
-            }
-        }
-
         private async Task EnsureHttpServerAsync()
         {
             if (_host == null)
@@ -150,9 +119,6 @@ namespace MartinCostello.Website.Integration
 
         private async Task CreateHttpServer()
         {
-            // Configure the server address for the server to listen on for HTTP requests
-            ClientOptions.BaseAddress = FindFreeServerAddress();
-
             var builder = CreateHostBuilder().ConfigureWebHost(ConfigureWebHost);
 
             _host = builder.Build();
@@ -160,6 +126,12 @@ namespace MartinCostello.Website.Integration
             // Force creation of the Kestrel server and start it
             var hostedService = _host.Services.GetService<IHostedService>();
             await hostedService!.StartAsync(default);
+
+            var server = _host.Services.GetRequiredService<IServer>();
+
+            ClientOptions.BaseAddress = server.Features.Get<IServerAddressesFeature>().Addresses
+                .Select((p) => new Uri(p))
+                .First();
         }
     }
 }


### PR DESCRIPTION
Dynamically bind the port without needing to use a `TcpListener`.
