### PR TITLE
Update Playwright

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="5.0.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.6" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageVersion Include="Microsoft.Playwright" Version="1.11.1-alpha-2" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.12.0-alpha-5" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageVersion Include="ReportGenerator" Version="4.8.9" />
     <PackageVersion Include="Serilog" Version="2.10.0" />


### PR DESCRIPTION
* Update to the latest release of Microsoft.Playwright and remove workaround for bug that's been fixed.
* Rename videos produced by tests to not have randomly generated names.
* Add support for different browser channels.