### PR TITLE
Refactor HttpServerFixture

### DIFF
--- a/tests/Website.Tests/Integration/HttpServerFixture.cs
+++ b/tests/Website.Tests/Integration/HttpServerFixture.cs
@@ -1,82 +1,46 @@
-// Copyright (c) Martin Costello, 2016. All rights reserved.
+﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System;
 using System.Linq;
-using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Xunit;
 
 namespace MartinCostello.Website.Integration
 {
     /// <summary>
     /// A test fixture representing an HTTP server hosting the application. This class cannot be inherited.
     /// </summary>
-    public sealed class HttpServerFixture : TestServerFixture, IAsyncLifetime
+    public sealed class HttpServerFixture : TestServerFixture
     {
         private IHost? _host;
         private bool _disposed;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="HttpServerFixture"/> class.
-        /// </summary>
-        public HttpServerFixture()
-            : base()
-        {
-        }
-
-        /// <summary>
         /// Gets the server address of the application.
         /// </summary>
-        public Uri ServerAddress => ClientOptions.BaseAddress;
-
-        /// <inheritdoc />
-        public override IServiceProvider? Services => _host?.Services;
-
-        /// <inheritdoc />
-        async Task IAsyncLifetime.InitializeAsync()
-            => await EnsureHttpServerAsync();
-
-        /// <inheritdoc />
-        async Task IAsyncLifetime.DisposeAsync()
+        public Uri ServerAddress
         {
-            if (_host != null)
+            get
             {
-                await _host.StopAsync();
-                _host.Dispose();
-                _host = null;
+                EnsureServer();
+                return ClientOptions.BaseAddress;
             }
         }
 
-        /// <summary>
-        /// Creates an <see cref="HttpClient"/> to communicate with the application.
-        /// </summary>
-        /// <returns>
-        /// An <see cref="HttpClient"/> that can be to used to make application requests.
-        /// </returns>
-        public HttpClient CreateHttpClient()
+        /// <inheritdoc />
+        public override IServiceProvider? Services
         {
-            var handler = new HttpClientHandler()
+            get
             {
-                AllowAutoRedirect = ClientOptions.AllowAutoRedirect,
-                CheckCertificateRevocationList = true,
-                MaxAutomaticRedirections = ClientOptions.MaxAutomaticRedirections,
-                UseCookies = ClientOptions.HandleCookies,
-            };
-
-            var client = new HttpClient(handler, disposeHandler: true);
-
-            ConfigureClient(client);
-
-            client.BaseAddress = ClientOptions.BaseAddress;
-
-            return client;
+                EnsureServer();
+                return _host!.Services!;
+            }
         }
 
         /// <inheritdoc />
@@ -91,6 +55,31 @@ namespace MartinCostello.Website.Integration
             // Configure the server address for the server to
             // listen on for HTTPS requests on a dynamic port.
             builder.UseUrls("https://127.0.0.1:0");
+        }
+
+        /// <inheritdoc />
+        protected override IHost CreateHost(IHostBuilder builder)
+        {
+            builder.ConfigureWebHost((p) => p.UseKestrel());
+
+            _host = builder.Build();
+            _host.Start();
+
+            var server = _host.Services.GetRequiredService<IServer>();
+            var addresses = server.Features.Get<IServerAddressesFeature>();
+
+            ClientOptions.BaseAddress = addresses!.Addresses
+                .Select((p) => new Uri(p))
+                .Last();
+
+            // The base class still needs a separate host using TestServer
+            var testHost = CreateHostBuilder()
+                .ConfigureWebHost((p) => p.UseTestServer())
+                .Build();
+
+            testHost.Start();
+
+            return testHost;
         }
 
         /// <inheritdoc />
@@ -109,29 +98,14 @@ namespace MartinCostello.Website.Integration
             }
         }
 
-        private async Task EnsureHttpServerAsync()
+        private void EnsureServer()
         {
-            if (_host == null)
+            if (_host is null)
             {
-                await CreateHttpServer();
+                using (CreateDefaultClient())
+                {
+                }
             }
-        }
-
-        private async Task CreateHttpServer()
-        {
-            var builder = CreateHostBuilder().ConfigureWebHost(ConfigureWebHost);
-
-            _host = builder.Build();
-
-            // Force creation of the Kestrel server and start it
-            var hostedService = _host.Services.GetService<IHostedService>();
-            await hostedService!.StartAsync(default);
-
-            var server = _host.Services.GetRequiredService<IServer>();
-
-            ClientOptions.BaseAddress = server.Features.Get<IServerAddressesFeature>() !.Addresses
-                .Select((p) => new Uri(p))
-                .First();
         }
     }
 }


### PR DESCRIPTION
Refactor `HttpServerFixture` to use a similar approach that the refactored `WebApplicationFactory<T>` in the [dotnet-minimal-api-integration-testing](dotnet-minimal-api-integration-testing) repo uses.

This should make it less work to switch to use minimal actions/hosting for .NET 6.
