### PR TITLE
Fix alignment

### DIFF
--- a/src/Website/Pages/Projects/Index.cshtml
+++ b/src/Website/Pages/Projects/Index.cshtml
@@ -59,7 +59,7 @@
             <div class="card-header">Lambda Test Server</div>
             <div class="card-body">
                 <p>
-                    A .NET class library to use with integration tests of .NET functions running in AWS Lambda.
+                    A .NET class library to use with integration tests of .NET functions in AWS Lambda.
                 </p>
                 <p>
                     @await Html.PartialAsync("_GitHubStar", "lambda-test-server")


### PR DESCRIPTION
Fix grid alignment by dropping a word, which should make it fit.