### PR TITLE
Add .NET version to comment

### DIFF
--- a/src/Website/Pages/Shared/_Layout.cshtml
+++ b/src/Website/Pages/Shared/_Layout.cshtml
@@ -53,5 +53,6 @@
     Instance:    @Environment.MachineName
     Commit:      @GitMetadata.Commit
     Timestamp:   @GitMetadata.Timestamp.ToString("u", CultureInfo.InvariantCulture)
+    Version:     @(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription)
 -->
 </html>


### PR DESCRIPTION
Also render the .NET version in the HTML comment at the bottom of pages.
