### PR TITLE
Fix Content-Security-Policy

### DIFF
--- a/src/Website/appsettings.json
+++ b/src/Website/appsettings.json
@@ -22,7 +22,7 @@
       "default-src": [ "buttons.github.io", "stackpath.bootstrapcdn.com", "platform.twitter.com" ],
       "font-src": [ "fonts.googleapis.com", "fonts.gstatic.com", "stackpath.bootstrapcdn.com", "use.fontawesome.com" ],
       "form-action": [ "platform.twitter.com", "syndication.twitter.com" ],
-      "img-src": [ "cdn.martincostello.com", "martincostello.azureedge.net", "stackoverflow.com", "static.licdn.com", "stats.g.doubleclick.net", "syndication.twitter.com" ],
+      "img-src": [ "cdn.martincostello.com", "martincostello.azureedge.net", "stackoverflow.com", "static.licdn.com", "stats.g.doubleclick.net", "syndication.twitter.com", "www.googletagmanager.com" ],
       "object-src": [ "ajax.cdnjs.com" ],
       "script-src": [ "api.github.com cdnjs.cloudflare.com", "az416426.vo.msecnd.net", "buttons.github.io", "stackpath.bootstrapcdn.com", "platform.twitter.com", "www.googletagmanager.com" ],
       "style-src": [ "buttons.github.io", "fonts.googleapis.com", "stackpath.bootstrapcdn.com", "use.fontawesome.com" ]


### PR DESCRIPTION
Allow loading images from `www.googletagmanager.com`.
