### PR TITLE
Use one property for ASP.NET Core version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,14 +1,14 @@
 <Project>
+  <PropertyGroup>
+    <MicrosoftAspNetCoreVersion>6.0.5</MicrosoftAspNetCoreVersion>
+  </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.msbuild" Version="3.1.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="1.4.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.2.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
-    <!-- Comment to help prevent dependabot merge conflicts -->
-    <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="6.0.5" />
-    <!-- Comment to help prevent dependabot merge conflicts -->
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
-    <!-- Comment to help prevent dependabot merge conflicts -->
+    <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.21.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />


### PR DESCRIPTION
Use a single MSBuild property for the version of all packages built from the dotnet/aspnetcore repo.
