### PR TITLE
Rename environment variables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ on:
   workflow_dispatch:
 
 env:
+  APPLICATION_URL_DEV: https://dev.martincostello.com
+  APPLICATION_URL_PROD: https://martincostello.com
   AZURE_WEBAPP_NAME: martincostello
   AZURE_WEBAPP_PACKAGE_PATH: ./artifacts/publish
   DOTNET_CLI_TELEMETRY_OPTOUT: true
@@ -22,8 +24,6 @@ env:
   DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
   NUGET_XMLDOC_MODE: skip
   TERM: xterm
-  WEBSITE_URL_DEV: https://dev.martincostello.com
-  WEBSITE_URL_PROD: https://martincostello.com
 
 jobs:
   build:
@@ -99,7 +99,7 @@ jobs:
     concurrency: development_environment
     environment:
       name: dev
-      url: ${{ env.WEBSITE_URL_DEV }}
+      url: ${{ env.APPLICATION_URL_DEV }}
 
     steps:
 
@@ -133,7 +133,7 @@ jobs:
       shell: pwsh
       run: dotnet test ./tests/Website.EndToEndTests --configuration Release --output ./artifacts
       env:
-        WEBSITE_URL: ${{ env.WEBSITE_URL_DEV }}
+        WEBSITE_URL: ${{ env.APPLICATION_URL_DEV }}
 
     - name: Publish screenshots
       uses: actions/upload-artifact@v3
@@ -166,7 +166,7 @@ jobs:
     concurrency: production_environment
     environment:
       name: production
-      url: ${{ env.WEBSITE_URL_PROD }}
+      url: ${{ env.APPLICATION_URL_PROD }}
 
     steps:
 
@@ -199,7 +199,7 @@ jobs:
       shell: pwsh
       run: dotnet test ./tests/Website.EndToEndTests --configuration Release --output ./artifacts
       env:
-        WEBSITE_URL: ${{ env.WEBSITE_URL_PROD }}
+        WEBSITE_URL: ${{ env.APPLICATION_URL_PROD }}
 
     - name: Publish screenshots
       uses: actions/upload-artifact@v3

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <CommitBranch Condition=" '$(CommitBranch)' == '' and '$(GITHUB_REF)' != '' ">$(GITHUB_REF.Substring(11))</CommitBranch>
+    <CommitBranch Condition=" '$(CommitBranch)' == '' and '$(GITHUB_REF_NAME)' != '' ">$(GITHUB_REF_NAME)</CommitBranch>
     <CommitHash Condition=" '$(CommitHash)' == '' ">$(GITHUB_SHA)</CommitHash>
     <DeployId Condition=" '$(DeployId)' == '' ">$(GITHUB_RUN_ID)</DeployId>
   </PropertyGroup>


### PR DESCRIPTION
- Rename to match conventions in more recent repos.
- Use `GITHUB_REF_NAME` instead of `GITHUB_REF` and trimming it so that it works properly with pull request branches.
