### PR TITLE
Remove MicrosoftAspNetCoreVersion

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,4 @@
 <Project>
-  <PropertyGroup>
-    <MicrosoftAspNetCoreVersion>7.0.3</MicrosoftAspNetCoreVersion>
-  </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.msbuild" Version="3.2.0" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.0.1" />


### PR DESCRIPTION
Remove the `MicrosoftAspNetCoreVersion` MSBuild property that is redundant with the new .NET SDK update workflow.
