### PR TITLE
.NET 8 preparation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ env:
   APPLICATION_URL_DEV: https://dev.martincostello.com
   APPLICATION_URL_PROD: https://martincostello.com
   AZURE_WEBAPP_NAME: martincostello
-  AZURE_WEBAPP_PACKAGE_PATH: ./artifacts/publish
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_GENERATE_ASPNET_CERTIFICATE: false
   DOTNET_MULTILEVEL_LOOKUP: 0
@@ -24,6 +23,7 @@ env:
   DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
   FORCE_COLOR: 1
   NUGET_XMLDOC_MODE: skip
+  PUBLISH_RUNTIME: win10-x64
   TERM: xterm
 
 jobs:
@@ -100,7 +100,7 @@ jobs:
       if: ${{ runner.os == 'Windows' }}
       with:
         name: webapp
-        path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+        path: ./artifacts/publish
 
     - name: Publish screenshots
       uses: actions/upload-artifact@v3

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -84,3 +84,4 @@ jobs:
       with:
         name: lighthouse
         path: ${{ github.workspace }}/artifacts
+        if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-﻿.DS_Store
+﻿.artifacts/
+.DS_Store
 .dotnetcli
 .metadata
 .settings

--- a/build.ps1
+++ b/build.ps1
@@ -1,7 +1,6 @@
 #! /usr/bin/env pwsh
 param(
     [Parameter(Mandatory = $false)][string] $Configuration = "Release",
-    [Parameter(Mandatory = $false)][string] $VersionSuffix = "",
     [Parameter(Mandatory = $false)][string] $OutputPath = "",
     [Parameter(Mandatory = $false)][switch] $SkipTests,
     [Parameter(Mandatory = $false)][string] $Runtime = ""
@@ -101,11 +100,6 @@ function DotNetPublish {
         $additionalArgs += "--self-contained"
         $additionalArgs += "--runtime"
         $additionalArgs += $Runtime
-    }
-
-    if (![string]::IsNullOrEmpty($VersionSuffix)) {
-        $additionalArgs += "--version-suffix"
-        $additionalArgs += $VersionSuffix
     }
 
     & $dotnet publish $Project --output $publishPath --configuration $Configuration $additionalArgs

--- a/tests/Website.Tests.Shared/BrowserFixture.cs
+++ b/tests/Website.Tests.Shared/BrowserFixture.cs
@@ -9,6 +9,7 @@ namespace MartinCostello.Website;
 public class BrowserFixture
 {
     private const string VideosDirectory = "videos";
+    private const string AssetsDirectory = ".";
 
     public BrowserFixture(
         BrowserFixtureOptions options,
@@ -66,7 +67,7 @@ public class BrowserFixture
             if (Options.CaptureTrace)
             {
                 string traceName = GenerateFileName(activeTestName, ".zip");
-                string path = Path.Combine("traces", traceName);
+                string path = Path.Combine(AssetsDirectory, "traces", traceName);
 
                 await context.Tracing.StopAsync(new() { Path = path });
 
@@ -139,7 +140,7 @@ public class BrowserFixture
         try
         {
             string fileName = GenerateFileName(testName, ".png");
-            string path = Path.Combine("screenshots", fileName);
+            string path = Path.Combine(AssetsDirectory, "screenshots", fileName);
 
             await page.ScreenshotAsync(new() { Path = path });
 
@@ -163,7 +164,7 @@ public class BrowserFixture
         try
         {
             string fileName = GenerateFileName(testName, ".webm");
-            string path = Path.Combine(VideosDirectory, fileName);
+            string path = Path.Combine(AssetsDirectory, VideosDirectory, fileName);
 
             await page.CloseAsync();
             await page.Video.SaveAsAsync(path);


### PR DESCRIPTION
Port changes from #1295 to minimise differences:

- Remove some environment variables from build scripts.
- Fail build if certain artifacts cannot be found.
- Ignore missing lighthouse artifacts.
- Remove version suffix.