### PR TITLE
Remove redundant suppressions

### DIFF
--- a/src/Website/Program.cs
+++ b/src/Website/Program.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA1812
-#pragma warning disable CA1852
-#pragma warning disable SA1516
-
 using System.IO.Compression;
 using System.Text.Json.Serialization.Metadata;
 using MartinCostello.Website;


### PR DESCRIPTION
Remove now-redundant suppressions for false-positive code analysis warnings.
