### PR TITLE
.NET preparation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,14 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
-    - '**/*.gitattributes'
-    - '**/*.gitignore'
-    - '**/*.md'
+      - '**/*.gitattributes'
+      - '**/*.gitignore'
+      - '**/*.md'
   pull_request:
-    branches: [ main, dotnet-vnext ]
+    branches:
+      - main
+      - dotnet-vnext
+      - dotnet-nightly
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main, dotnet-vnext ]
+    branches:
+      - main
+      - dotnet-vnext
+      - dotnet-nightly
   schedule:
     - cron: '0 6 * * 1'
   workflow_dispatch:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,10 @@ name: dependency-review
 
 on:
   pull_request:
-    branches: [ main, dotnet-vnext ]
+    branches:
+      - main
+      - dotnet-vnext
+      - dotnet-nightly
 
 permissions:
   contents: read

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -2,7 +2,10 @@ name: lighthouse
 
 on:
   pull_request:
-    branches: [ main, dotnet-vnext ]
+    branches:
+      - main
+      - dotnet-vnext
+      - dotnet-nightly
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -12,7 +12,7 @@ jobs:
   update-sdk:
     uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@638a19214b5333029150c3347f4c4552c17ed926 # v2.2.4
     with:
-      labels: "dependencies,.NET"
+      labels: 'dependencies,.NET'
       user-email: ${{ vars.GIT_COMMIT_USER_EMAIL }}
       user-name: ${{ vars.GIT_COMMIT_USER_NAME }}
     secrets:

--- a/tests/Website.Tests/Website.Tests.csproj
+++ b/tests/Website.Tests/Website.Tests.csproj
@@ -30,6 +30,7 @@
     <CoverletOutput>$([System.IO.Path]::Combine($(OutputPath), 'coverage', 'coverage'))</CoverletOutput>
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[Website.*Tests*]*,[xunit.*]*</Exclude>
+    <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
     <Threshold>65</Threshold>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Enable pull request triggers for the `dotnet-nightly` branch.
- Exclude code decorated with `[GeneratedCode]` from code coverage.
