### PR TITLE
Do not start TestServer

### DIFF
--- a/tests/Website.Tests/Integration/HttpServerFixture.cs
+++ b/tests/Website.Tests/Integration/HttpServerFixture.cs
@@ -71,8 +71,6 @@ public sealed class HttpServerFixture : TestServerFixture
             .Select((p) => new Uri(p))
             .Last();
 
-        testHost.Start();
-
         return testHost;
     }
 


### PR DESCRIPTION
TestServer shouldn't need to be used, and not doing so should speed things up.