### PR TITLE
Bump xunit to 2.7.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,8 +17,8 @@
     <PackageVersion Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
-    <PackageVersion Include="xunit" Version="2.6.6" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6" />
+    <PackageVersion Include="xunit" Version="2.7.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Bump xunit and xunit.runner.visualstudio to their latest versions because dependabot is incapable of doing it.
