### PR TITLE
Change BeforeTargets

### DIFF
--- a/src/Website/Website.csproj
+++ b/src/Website/Website.csproj
@@ -31,7 +31,7 @@
     <None Remove="assets\scripts\**\*.ts" />
     <TypeScriptCompile Include="assets\scripts\**\*.ts" />
   </ItemGroup>
-  <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
+  <Target Name="PrepublishScript" BeforeTargets="BeforeBuild">
     <Exec Command="npm ci" Condition=" '$(CI)' != '' and !Exists('$(MSBuildThisFileDirectory)\node_modules') " />
     <Exec Command="npm install" Condition=" '$(CI)' == '' and !Exists('$(MSBuildThisFileDirectory)\node_modules') " />
     <Exec Command="npm run build" Condition=" !Exists('$(MSBuildThisFileDirectory)\wwwroot\assets\js\main.js') " />


### PR DESCRIPTION
Use `BeforeBuild` so that `dotnet test` on a fresh clone without using the build script will compile the assets.
