### PR TITLE
Prepare to remove Windows deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,22 +142,26 @@ jobs:
         if-no-files-found: ignore
 
     - name: Docker log in
-      uses: azure/docker-login@v1
+      uses: docker/login-action@v3
       if: env.PUBLISH_CONTAINER == 'true'
       with:
-        login-server: ${{ env.CONTAINER_REGISTRY }}
+        registry: ${{ env.CONTAINER_REGISTRY }}
         username: ${{ secrets.ACR_REGISTRY_USERNAME }}
         password: ${{ secrets.ACR_REGISTRY_PASSWORD }}
 
     - name: Publish container
       id: publish-container
-      if: env.PUBLISH_CONTAINER == 'true'
+      if: ${{ runner.os == 'Linux' }}
       shell: pwsh
+      env:
+        ContainerRegistry: ${{ env.PUBLISH_CONTAINER == 'true' && env.CONTAINER_REGISTRY || '' }}
       run: |
         dotnet publish ./src/Website --arch x64 --os linux -p:PublishProfile=DefaultContainer
-        $containerImage = "${env:CONTAINER_REGISTRY}/${env:GITHUB_REPOSITORY}"
-        "container-image=${containerImage}" >> "${env:GITHUB_OUTPUT}"
-        "container-tag=${containerImage}:github-${env:GITHUB_RUN_NUMBER}" >> "${env:GITHUB_OUTPUT}"
+        if (-Not [string]::IsNullOrWhiteSpace(${env:CONTAINER_REGISTRY})) {
+          $containerImage = "${env:CONTAINER_REGISTRY}/${env:GITHUB_REPOSITORY}"
+          "container-image=${containerImage}" >> "${env:GITHUB_OUTPUT}"
+          "container-tag=${containerImage}:github-${env:GITHUB_RUN_NUMBER}" >> "${env:GITHUB_OUTPUT}"
+        }
 
   deploy-dev:
     if: github.event.repository.fork == false && github.ref_name == github.event.repository.default_branch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,13 +193,42 @@ jobs:
         app-name: ${{ env.AZURE_WEBAPP_NAME }}
         slot-name: dev
 
-    #- name: Deploy container to Azure App Service
-    #  uses: azure/webapps-deploy@v3
-    #  if: needs.build.outputs.container-tag != ''
-    #  with:
-    #    app-name: 'website-martincostello'
-    #    images: ${{ needs.build.outputs.container-tag }}
-    #    slot-name: dev
+    - name: Deploy container to Azure App Service
+      uses: azure/webapps-deploy@v3
+      if: needs.build.outputs.container-tag != ''
+      with:
+        app-name: 'website-martincostello'
+        images: ${{ needs.build.outputs.container-tag }}
+        slot-name: dev
+
+    - name: Check application health
+      shell: pwsh
+      env:
+        APPLICATION_URL: ${{ env.APPLICATION_URL_DEV }}
+      run: |
+        $delay = 10
+        $limit = 10
+        $success = $false
+        for ($i = 0; $i -lt $limit; $i++) {
+          $response = $null
+          try {
+            $response = Invoke-WebRequest -Uri "${env:APPLICATION_URL}/version" -Method Get -UseBasicParsing
+          } catch {
+            $response = $_.Exception.Response
+          }
+          if (($null -ne $response) -And ($response.StatusCode -eq 200)) {
+            $json = $response.Content | ConvertFrom-Json
+            $version = $json.applicationVersion
+            if ((-Not [string]::IsNullOrWhiteSpace($version)) -And $version.Contains(${env:GITHUB_SHA})) {
+              $success = $true
+              break
+            }
+          }
+          Start-Sleep -Seconds $delay
+        }
+        if (-Not $success) {
+          throw "${env:APPLICATION_URL} did not return a successful status code and the expected version within the time limit after $limit attempts."
+        }
 
   test-dev:
     name: test-dev
@@ -230,31 +259,6 @@ jobs:
           ~/AppData/Local/ms-playwright
           ~/.cache/ms-playwright
           ~/Library/Caches/ms-playwright
-
-    - name: Check application health
-      shell: pwsh
-      env:
-        APPLICATION_URL: ${{ env.APPLICATION_URL_DEV }}
-      run: |
-        $delay = 10
-        $limit = 10
-        $success = $false
-        for ($i = 0; $i -lt $limit; $i++) {
-          $response = $null
-          try {
-            $response = Invoke-WebRequest -Uri $env:APPLICATION_URL -Method Get -UseBasicParsing
-          } catch {
-            $response = $_.Exception.Response
-          }
-          if (($null -ne $response) -And ($response.StatusCode -eq 200)) {
-            $success = $true
-            break
-          }
-          Start-Sleep -Seconds $delay
-        }
-        if (-Not $success) {
-          throw "$($env:APPLICATION_URL) did not return a successful status code within the time limit after $limit attempts."
-        }
 
     - name: Run end-to-end tests
       shell: pwsh
@@ -325,6 +329,35 @@ jobs:
         app-name: 'website-martincostello'
         images: ${{ needs.build.outputs.container-tag }}
 
+    - name: Check application health
+      shell: pwsh
+      env:
+        APPLICATION_URL: ${{ env.APPLICATION_URL_PROD }}
+      run: |
+        $delay = 10
+        $limit = 10
+        $success = $false
+        for ($i = 0; $i -lt $limit; $i++) {
+          $response = $null
+          try {
+            $response = Invoke-WebRequest -Uri "${env:APPLICATION_URL}/version" -Method Get -UseBasicParsing
+          } catch {
+            $response = $_.Exception.Response
+          }
+          if (($null -ne $response) -And ($response.StatusCode -eq 200)) {
+            $json = $response.Content | ConvertFrom-Json
+            $version = $json.applicationVersion
+            if ((-Not [string]::IsNullOrWhiteSpace($version)) -And $version.Contains(${env:GITHUB_SHA})) {
+              $success = $true
+              break
+            }
+          }
+          Start-Sleep -Seconds $delay
+        }
+        if (-Not $success) {
+          throw "${env:APPLICATION_URL} did not return a successful status code and the expected version within the time limit after $limit attempts."
+        }
+
   test-prod:
     name: test-prod
     needs: deploy-prod
@@ -354,31 +387,6 @@ jobs:
           ~/AppData/Local/ms-playwright
           ~/.cache/ms-playwright
           ~/Library/Caches/ms-playwright
-
-    - name: Check application health
-      shell: pwsh
-      env:
-        APPLICATION_URL: ${{ env.APPLICATION_URL_PROD }}
-      run: |
-        $delay = 10
-        $limit = 10
-        $success = $false
-        for ($i = 0; $i -lt $limit; $i++) {
-          $response = $null
-          try {
-            $response = Invoke-WebRequest -Uri $env:APPLICATION_URL -Method Get -UseBasicParsing
-          } catch {
-            $response = $_.Exception.Response
-          }
-          if (($null -ne $response) -And ($response.StatusCode -eq 200)) {
-            $success = $true
-            break
-          }
-          Start-Sleep -Seconds $delay
-        }
-        if (-Not $success) {
-          throw "$($env:APPLICATION_URL) did not return a successful status code within the time limit after $limit attempts."
-        }
 
     - name: Run end-to-end tests
       shell: pwsh

--- a/build.ps1
+++ b/build.ps1
@@ -93,7 +93,6 @@ function DotNetPublish {
     $additionalArgs = @()
 
     if (![string]::IsNullOrEmpty($Runtime)) {
-        $additionalArgs += "--self-contained"
         $additionalArgs += "--runtime"
         $additionalArgs += $Runtime
     }

--- a/src/Website/ApplicationJsonSerializerContext.cs
+++ b/src/Website/ApplicationJsonSerializerContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using MartinCostello.Website.Models;
 
@@ -12,6 +13,7 @@ namespace MartinCostello.Website;
 [JsonSerializable(typeof(GuidResponse))]
 [JsonSerializable(typeof(HashRequest))]
 [JsonSerializable(typeof(HashResponse))]
+[JsonSerializable(typeof(JsonObject))]
 [JsonSerializable(typeof(MachineKeyResponse))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
 internal sealed partial class ApplicationJsonSerializerContext : JsonSerializerContext

--- a/src/Website/Website.csproj
+++ b/src/Website/Website.csproj
@@ -4,6 +4,7 @@
     <Description>https://martincostello.com/</Description>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
+    <InvariantGlobalization>true</InvariantGlobalization>
     <OutputType>Exe</OutputType>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RootNamespace>MartinCostello.Website</RootNamespace>
@@ -13,21 +14,26 @@
     <TypeScriptToolsVersion>latest</TypeScriptToolsVersion>
     <UserSecretsId>martincostello.com</UserSecretsId>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(CI)' == 'true' ">
-    <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
+  <PropertyGroup>
+    <!-- TODO Remove if https://github.com/dotnet/sdk/issues/40500 implemented or when no longer only in nightly -->
     <ContainerBaseImage>mcr.microsoft.com/dotnet/nightly/runtime-deps:8.0-noble-chiseled</ContainerBaseImage>
+    <ContainerFamily>noble-chiseled</ContainerFamily>
+    <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
+    <PublishSelfContained>true</PublishSelfContained>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(CI)' == 'true' ">
     <ContainerImageTags>github-$(GITHUB_RUN_NUMBER);latest</ContainerImageTags>
-    <ContainerRegistry>$(GITHUB_REPOSITORY_OWNER).azurecr.io</ContainerRegistry>
     <ContainerRepository>$(GITHUB_REPOSITORY)</ContainerRepository>
     <ContainerTitle>$(GITHUB_REPOSITORY)</ContainerTitle>
     <ContainerVendor>$(GITHUB_REPOSITORY_OWNER)</ContainerVendor>
     <ContainerVersion>$(GITHUB_SHA)</ContainerVersion>
-    <PublishSelfContained>true</PublishSelfContained>
   </PropertyGroup>
+  <ItemGroup>
+    <ContainerPort Include="8080" Type="tcp" />
+  </ItemGroup>
   <ItemGroup Condition=" '$(CI)' == 'true' ">
     <ContainerLabel Include="com.docker.extension.changelog" Value="$(GITHUB_SERVER_URL)/$(GITHUB_REPOSITORY)/commit/$(GITHUB_SHA)" />
     <ContainerLabel Include="com.docker.extension.publisher-url" Value="$(GITHUB_SERVER_URL)/$(GITHUB_REPOSITORY_OWNER)" />
-    <ContainerPort Include="8080" Type="tcp" />
   </ItemGroup>
   <ItemGroup>
     <Content Update="appsettings.json" CopyToOutputDirectory="PreserveNewest" />

--- a/src/Website/wwwroot/robots933456.txt
+++ b/src/Website/wwwroot/robots933456.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow:
+
+Sitemap: https://martincostello.com/sitemap.xml

--- a/tests/Website.EndToEndTests/ResourceTests.cs
+++ b/tests/Website.EndToEndTests/ResourceTests.cs
@@ -31,6 +31,7 @@ public class ResourceTests(WebsiteFixture fixture, ITestOutputHelper outputHelpe
     [InlineData("/not-found.html", "text/html")]
     [InlineData("/projects", "text/html")]
     [InlineData("/robots.txt", "text/plain")]
+    [InlineData("/robots933456.txt", "text/plain")]
     [InlineData("/service-worker.js", "text/javascript")]
     [InlineData("/sitemap.xml", "text/xml")]
     [InlineData("/tools", "text/html")]

--- a/tests/Website.EndToEndTests/ResourceTests.cs
+++ b/tests/Website.EndToEndTests/ResourceTests.cs
@@ -34,6 +34,7 @@ public class ResourceTests(WebsiteFixture fixture, ITestOutputHelper outputHelpe
     [InlineData("/service-worker.js", "text/javascript")]
     [InlineData("/sitemap.xml", "text/xml")]
     [InlineData("/tools", "text/html")]
+    [InlineData("/version", "application/json")]
     public async Task Can_Load_Resource_As_Get(string requestUri, string contentType)
     {
         // Arrange

--- a/tests/Website.Tests/Integration/ResourceTests.cs
+++ b/tests/Website.Tests/Integration/ResourceTests.cs
@@ -44,6 +44,7 @@ public class ResourceTests(TestServerFixture fixture, ITestOutputHelper outputHe
     [InlineData("/service-worker.js", "text/javascript")]
     [InlineData("/sitemap.xml", "text/xml")]
     [InlineData("/tools", "text/html")]
+    [InlineData("/version", "application/json")]
     public async Task Can_Load_Resource_As_Get(string requestUri, string contentType)
     {
         // Arrange

--- a/tests/Website.Tests/Integration/ResourceTests.cs
+++ b/tests/Website.Tests/Integration/ResourceTests.cs
@@ -41,6 +41,7 @@ public class ResourceTests(TestServerFixture fixture, ITestOutputHelper outputHe
     [InlineData("/not-found.html", "text/html")]
     [InlineData("/projects", "text/html")]
     [InlineData("/robots.txt", "text/plain")]
+    [InlineData("/robots933456.txt", "text/plain")]
     [InlineData("/service-worker.js", "text/javascript")]
     [InlineData("/sitemap.xml", "text/xml")]
     [InlineData("/tools", "text/html")]


### PR DESCRIPTION
- Add a simple version endpoint that can be used to easily determine where the request from a given domain is being served by/from.
- Add content for `robots933456.txt` to stop 404s from Azure App Service's container readiness checks.
- Move the health check to the deploy job, rather than before the tests.
- Deploy container to dev slot.
- Use docker/login-action to fix Node.js v16 warnings.
- Always publish the image on Linux, but publish it locally in most cases.
- Enable invariant globalization.
