### PR TITLE
Move package references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,9 +25,4 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
-    <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />
-    <PackageReference Include="GitHubActionsTestLogger" NoWarn="RT0003" />
-    <PackageReference Include="ReportGenerator" PrivateAssets="All" />
-  </ItemGroup>
 </Project>

--- a/tests/Website.EndToEndTests/Website.EndToEndTests.csproj
+++ b/tests/Website.EndToEndTests/Website.EndToEndTests.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\Website.Tests.Shared\Website.Tests.Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" NoWarn="RT0003" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Xunit.SkippableFact" />

--- a/tests/Website.Tests/Website.Tests.csproj
+++ b/tests/Website.Tests/Website.Tests.csproj
@@ -18,8 +18,11 @@
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="coverlet.msbuild" />
+    <PackageReference Include="GitHubActionsTestLogger" NoWarn="RT0003" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="ReportGenerator" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Move package references out of Directory.Packages.props to workaround dependabot issue.
