### PR TITLE
Avoid HTTPS redirection warning

### DIFF
--- a/src/Website/Program.cs
+++ b/src/Website/Program.cs
@@ -124,8 +124,15 @@ if (!isDevelopment)
 
 app.UseStatusCodePagesWithReExecute("/error", "?id={0}");
 
-app.UseHttpsRedirection()
-   .UseHsts();
+if (!app.Environment.IsDevelopment())
+{
+    app.UseHsts();
+
+    if (!string.Equals(app.Configuration["ForwardedHeaders_Enabled"], bool.TrueString, StringComparison.OrdinalIgnoreCase))
+    {
+        app.UseHttpsRedirection();
+    }
+}
 
 app.UseResponseCompression();
 


### PR DESCRIPTION
When deployed with `ForwardedHeaders_Enabled=true` do not enable HTTPS redirection to avoid warnings being logged by platform-level HTTP requests (such as health checks).
