### PR TITLE
Update actionlint to version 1.7.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,6 @@ jobs:
       run: echo "::add-matcher::.github/actionlint-matcher.json"
 
     - name: Lint workflows
-      uses: docker://rhysd/actionlint@sha256:daa1edae4a6366f320b68abb60b74fb59a458c17b61938d3c62709d92b231558 # v1.6.27
+      uses: docker://rhysd/actionlint@sha256:5acca218639222e4afbc82fc6e9ef56cbe646ade3b07f3f5ec364b638258a244 # v1.7.0
       with:
-        # Remove -ignore once v1.6.28 released - see https://github.com/rhysd/actionlint/pull/418#issuecomment-2089713941
-        args: -color -ignore "attestations"
+        args: -color


### PR DESCRIPTION
Related to #1964

Updates the actionlint version to 1.7.0 in the project's GitHub Actions workflow.
- Changes the Docker image used for actionlint to the SHA256 digest corresponding to version 1.7.0.
- Removes the `-ignore "attestations"` argument from the `args` parameter, as the workaround is no longer needed with the update.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/martincostello/website/issues/1964?shareId=b604df47-bb57-4128-a3ff-af1ccbd4cb60).