### PR TITLE
Switch to Azure Monitor exporter

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.1" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.2.0" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />

--- a/src/Website/Extensions/ILoggingBuilderExtensions.cs
+++ b/src/Website/Extensions/ILoggingBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using Azure.Monitor.OpenTelemetry.Exporter;
 using OpenTelemetry.Logs;
 
 namespace Microsoft.Extensions.Logging;
@@ -23,6 +24,11 @@ public static class ILoggingBuilderExtensions
         {
             p.IncludeFormattedMessage = true;
             p.IncludeScopes = true;
+
+            if (TelemetryExtensions.IsAzureMonitorConfigured())
+            {
+                p.AddAzureMonitorLogExporter();
+            }
 
             if (TelemetryExtensions.IsOtlpCollectorConfigured())
             {

--- a/src/Website/Website.csproj
+++ b/src/Website/Website.csproj
@@ -20,7 +20,7 @@
     <ContainerFamily>noble-chiseled</ContainerFamily>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
     <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />


### PR DESCRIPTION
Switch to Azure.Monitor.OpenTelemetry.Exporter from Azure.Monitor.OpenTelemetry.AspNetCore as the latter is not AoT friendly.
