### PR TITLE
Remove TypeScript SDK

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -8,7 +8,6 @@
     "Microsoft.VisualStudio.Component.Roslyn.Compiler",
     "Microsoft.VisualStudio.Component.Roslyn.LanguageServices",
     "Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions",
-    "Microsoft.VisualStudio.Component.TypeScript.4.2",
     "Microsoft.VisualStudio.Component.JavaScript.TypeScript",
     "Microsoft.VisualStudio.Component.JavaScript.Diagnostics",
     "Component.Microsoft.VisualStudio.RazorExtension",


### PR DESCRIPTION
Remove the TypeScript SDK to resolve warning when opening the solution.