### PR TITLE
Use benchmarkdotnet-results-publisher

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,19 +52,13 @@ jobs:
         "repo-name=${repoName}" >> ${env:GITHUB_OUTPUT}
 
     - name: Publish results
-      uses: benchmark-action/github-action-benchmark@v1
+      uses: martincostello/benchmarkdotnet-results-publisher@v1
       with:
-        auto-push: true
-        alert-comment-cc-users: '@${{ github.repository_owner }}'
-        benchmark-data-dir-path: ${{ steps.get-repo-name.outputs.repo-name }}
-        comment-on-alert: true
-        fail-on-alert: true
-        gh-pages-branch: ${{ github.ref_name }}
-        gh-repository: 'github.com/${{ github.repository_owner }}/benchmarks'
-        github-token: ${{ secrets.BENCHMARKS_TOKEN }}
+        branch: ${{ github.ref_name }}
         name: Website
-        output-file-path: BenchmarkDotNet.Artifacts/results/MartinCostello.Website.Benchmarks.WebsiteBenchmarks-report-full-compressed.json
-        tool: benchmarkdotnet
+        output-file-path: '${{ steps.get-repo-name.outputs.repo-name }}/data.json'
+        repo: '${{ github.repository_owner }}/benchmarks'
+        repo-token: ${{ secrets.BENCHMARKS_TOKEN }}
 
     - name: Output summary
       shell: pwsh


### PR DESCRIPTION
Use `martincostello/benchmarkdotnet-results-publisher` instead of `benchmark-action/github-action-benchmark`.
