### PR TITLE
Update link colour with variable

### DIFF
--- a/src/Website/assets/styles/main.css
+++ b/src/Website/assets/styles/main.css
@@ -3,6 +3,11 @@
     Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 */
 
+:root {
+  --bs-link-color: #0f7661;
+  --bs-link-color-rgb: 15, 118, 97;
+}
+
 /* stylelint-disable-next-line media-feature-name-no-vendor-prefix */
 @media (-webkit-min-device-pixel-ratio: 1.25), (resolution >= 120dpi) {
     html {
@@ -12,10 +17,6 @@
     body {
         font-size: 1rem;
     }
-}
-
-a {
-    color: #0f7661;
 }
 
 .body-content {


### PR DESCRIPTION
Override bootstrap variable to change link colour, rather than override `a` itself.
