### PR TITLE
Update NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,19 +12,19 @@
     <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="9.0.0-rc.1.24452.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-rc.1.24452.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageVersion Include="Microsoft.Playwright" Version="1.46.0" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.47.0" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.6.2" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Resources.Azure" Version="1.0.0-beta.8" />
+    <PackageVersion Include="OpenTelemetry.Resources.Azure" Version="1.0.0-beta.9" />
     <PackageVersion Include="OpenTelemetry.Resources.Container" Version="1.0.0-beta.9" />
     <PackageVersion Include="RazorSlices" Version="0.8.1" />
     <PackageVersion Include="ReportGenerator" Version="5.3.9" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
-    <PackageVersion Include="xunit" Version="2.9.0" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>


### PR DESCRIPTION
Update NuGet packages to their latest versions while dependabot does not support .NET 9.
