### PR TITLE
Remove report-uri

### DIFF
--- a/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
@@ -180,9 +180,9 @@ public sealed class CustomHttpHeadersMiddleware
             builder.Append("upgrade-insecure-requests;");
         }
 
-        if (options?.ExternalLinks?.Reports?.ContentSecurityPolicy != null)
+        if (options?.ExternalLinks?.Reports?.ContentSecurityPolicy is { } reportUri)
         {
-            builder.Append(CultureInfo.InvariantCulture, $"report-uri {options.ExternalLinks.Reports.ContentSecurityPolicy};");
+            builder.Append(CultureInfo.InvariantCulture, $"report-uri {reportUri};");
         }
 
         return builder.ToString();
@@ -213,16 +213,16 @@ public sealed class CustomHttpHeadersMiddleware
 
         if (enforce)
         {
-            if (options?.ExternalLinks?.Reports?.ExpectCTEnforce != null)
+            if (options?.ExternalLinks?.Reports?.ExpectCTEnforce is { } enforceUri)
             {
-                builder.Append(CultureInfo.InvariantCulture, $" report-uri {options.ExternalLinks.Reports.ExpectCTEnforce}");
+                builder.Append(CultureInfo.InvariantCulture, $" report-uri {enforceUri}");
             }
         }
         else
         {
-            if (options?.ExternalLinks?.Reports?.ExpectCTReportOnly != null)
+            if (options?.ExternalLinks?.Reports?.ExpectCTReportOnly is { } reportUri)
             {
-                builder.Append(CultureInfo.InvariantCulture, $" report-uri {options.ExternalLinks.Reports.ExpectCTReportOnly}");
+                builder.Append(CultureInfo.InvariantCulture, $" report-uri {reportUri}");
             }
         }
 

--- a/src/Website/Options/ReportOptions.cs
+++ b/src/Website/Options/ReportOptions.cs
@@ -27,9 +27,4 @@ public sealed class ReportOptions
     /// Gets or sets the URI to use for <c>Expect-CT</c> when not enforced.
     /// </summary>
     public Uri? ExpectCTReportOnly { get; set; }
-
-    /// <summary>
-    /// Gets or sets the URI to use for <c>Expect-Staple</c>.
-    /// </summary>
-    public Uri? ExpectStaple { get; set; }
 }

--- a/src/Website/appsettings.json
+++ b/src/Website/appsettings.json
@@ -79,11 +79,10 @@
       "Blog": "https://blog.martincostello.com/",
       "Cdn": "https://cdn.martincostello.com/",
       "Reports": {
-        "ContentSecurityPolicy": "https://martincostello.report-uri.io/r/default/csp/enforce",
-        "ContentSecurityPolicyReportOnly": "https://martincostello.report-uri.io/r/default/csp/reportOnly",
-        "ExpectCTEnforce": "https://martincostello.report-uri.io/r/default/ct/enforce",
-        "ExpectCTReportOnly": "https://martincostello.report-uri.io/r/default/ct/reportOnly",
-        "ExpectStaple": "https://martincostello.report-uri.io/r/default/staple/reportOnly"
+        "ContentSecurityPolicy": "",
+        "ContentSecurityPolicyReportOnly": "",
+        "ExpectCTEnforce": "",
+        "ExpectCTReportOnly": ""
       }
     },
     "Metadata": {

--- a/tests/Website.Tests/testsettings.json
+++ b/tests/Website.Tests/testsettings.json
@@ -21,11 +21,10 @@
       "Blog": "https://blog.martincostello.com/",
       "Cdn": "https://cdn.martincostello.com/",
       "Reports": {
-        "ContentSecurityPolicy": "https://martincostello.report-uri.io/r/default/csp/enforce",
-        "ContentSecurityPolicyReportOnly": "https://martincostello.report-uri.io/r/default/csp/reportOnly",
-        "ExpectCTEnforce": "https://martincostello.report-uri.io/r/default/ct/enforce",
-        "ExpectCTReportOnly": "https://martincostello.report-uri.io/r/default/ct/reportOnly",
-        "ExpectStaple": "https://martincostello.report-uri.io/r/default/staple/reportOnly"
+        "ContentSecurityPolicy": "",
+        "ContentSecurityPolicyReportOnly": "",
+        "ExpectCTEnforce": "",
+        "ExpectCTReportOnly": ""
       }
     },
     "Metadata": {


### PR DESCRIPTION
- Remove usage of report-uri.io as the free tier is being shutdown in ~90 days.
- Remove unused `ExpectStaple` property.
