### PR TITLE
Remove azureedge.net

### DIFF
--- a/src/Website/appsettings.json
+++ b/src/Website/appsettings.json
@@ -48,7 +48,6 @@
       ],
       "img-src": [
         "cdn.martincostello.com",
-        "martincostello.azureedge.net",
         "stackoverflow.com",
         "static.licdn.com",
         "stats.g.doubleclick.net",


### PR DESCRIPTION
Remove redundant image source for `martincostello.azureedge.net`.
