### PR TITLE
Add SDK hint paths

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,11 +3,15 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
-  "extensions": [
-    "editorconfig.editorconfig",
-    "ms-dotnettools.csharp",
-    "ms-vscode.PowerShell"
-  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "editorconfig.editorconfig",
+        "ms-dotnettools.csharp",
+        "ms-vscode.PowerShell"
+      ]
+    }
+  },
   "forwardPorts": [ 5000 ],
   "portsAttributes":{
     "5000": {
@@ -18,6 +22,6 @@
   },
   "postCreateCommand": "./build.ps1 -SkipTests",
   "remoteEnv": {
-    "PATH": "/root/.dotnet/tools:${containerWorkspaceFolder}/.dotnetcli:${containerEnv:PATH}"
+    "PATH": "/root/.dotnet/tools:${containerWorkspaceFolder}/.dotnet:${containerEnv:PATH}"
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 ﻿.DS_Store
-.dotnetcli
+.dotnet
 .metadata
 .settings
 .vs

--- a/build.ps1
+++ b/build.ps1
@@ -34,7 +34,7 @@ else {
 
 if ($installDotNetSdk) {
 
-    $env:DOTNET_INSTALL_DIR = Join-Path $PSScriptRoot ".dotnetcli"
+    $env:DOTNET_INSTALL_DIR = Join-Path $PSScriptRoot ".dotnet"
     $sdkPath = Join-Path $env:DOTNET_INSTALL_DIR "sdk\$dotnetVersion"
 
     if (!(Test-Path $sdkPath)) {

--- a/global.json
+++ b/global.json
@@ -2,6 +2,8 @@
   "sdk": {
     "version": "9.0.202",
     "allowPrerelease": false,
-    "rollForward": "latestMajor"
+    "rollForward": "latestMajor",
+    "paths": [ ".dotnet", "$host$" ],
+    "errorMessage": "The required version of the .NET SDK could not be found. Please run ./build.ps1 to bootstrap the .NET SDK."
   }
 }

--- a/startvs.cmd
+++ b/startvs.cmd
@@ -4,8 +4,8 @@ SETLOCAL
 :: This command launches a Visual Studio solution with environment variables required to use a local version of the .NET SDK.
 
 :: This tells .NET to use the same dotnet.exe that the build script uses.
-SET DOTNET_ROOT=%~dp0.dotnetcli
-SET DOTNET_ROOT(x86)=%~dp0.dotnetcli\x86
+SET DOTNET_ROOT=%~dp0.dotnet
+SET DOTNET_ROOT(x86)=%~dp0.dotnet\x86
 
 :: Put our local dotnet.exe on PATH first so Visual Studio knows which one to use.
 SET PATH=%DOTNET_ROOT%;%PATH%

--- a/startvscode.cmd
+++ b/startvscode.cmd
@@ -4,8 +4,8 @@ SETLOCAL
 :: This command launches Visual Studio Code with environment variables required to use a local version of the .NET SDK.
 
 :: This tells .NET to use the same dotnet.exe that the build script uses.
-SET DOTNET_ROOT=%~dp0.dotnetcli
-SET DOTNET_ROOT(x86)=%~dp0.dotnetcli\x86
+SET DOTNET_ROOT=%~dp0.dotnet
+SET DOTNET_ROOT(x86)=%~dp0.dotnet\x86
 
 :: Put our local dotnet.exe on PATH first so Visual Studio Code knows which one to use.
 SET PATH=%DOTNET_ROOT%;%PATH%


### PR DESCRIPTION
- Add new .NET 10 properties for locating the .NET SDK.
- Move from `.dotnetcli` to `.dotnet`.
- Avoid using deprecated devcontainer setting.