### PR TITLE
Disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,42 +1,7 @@
 version: 2
 updates:
-- package-ecosystem: "docker"
-  directory: ".devcontainer"
-  schedule:
-    interval: daily
-    time: "05:30"
-    timezone: Europe/London
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "05:30"
-    timezone: Europe/London
 - package-ecosystem: nuget
   directory: "/"
-  groups:
-    OpenTelemetry:
-      patterns:
-        - OpenTelemetry*
-    xunit:
-      patterns:
-        - xunit*
   schedule:
-    interval: daily
-    time: "05:30"
+    interval: yearly
     timezone: Europe/London
-  open-pull-requests-limit: 99
-- package-ecosystem: npm
-  directory: "/src/Website"
-  groups:
-    babel:
-      patterns:
-        - "@babel/*"
-    typescript-eslint:
-      patterns:
-        - "@typescript-eslint/*"
-  schedule:
-    interval: daily
-    time: "05:30"
-    timezone: Europe/London
-  open-pull-requests-limit: 99


### PR DESCRIPTION
"Disable" dependabot, but leave the configuration file in place to show to automated tools that automated dependency updates are used in case they do not recognise Renovate and for to keep the ignore approval rules in place for Costellobot.
