### PR TITLE
Remove deployment.environment.name

### DIFF
--- a/src/Website/ApplicationTelemetry.cs
+++ b/src/Website/ApplicationTelemetry.cs
@@ -31,7 +31,6 @@ public static class ApplicationTelemetry
     /// </summary>
     public static ResourceBuilder ResourceBuilder { get; } = ResourceBuilder.CreateDefault()
         .AddService(ServiceName, ServiceName, ServiceVersion)
-        .AddAttributes([new KeyValuePair<string, object>("deployment.environment.name", Environment.GetEnvironmentVariable("Azure__Environment") ?? "production")])
         .AddAzureAppServiceDetector()
         .AddContainerDetector()
         .AddHostDetector()


### PR DESCRIPTION
Remove `deployment.environment.name` as it doesn't seem to work and can be overridden from environment variables instead.
