### PR TITLE
Remove KubernetesClient version override

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,8 +10,6 @@
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="JunitXml.TestLogger" Version="6.1.0" />
-    <!-- HACK Resolves GHSA-w7r3-mgwf-4mqq -->
-    <PackageVersion Include="KubernetesClient" Version="17.0.14" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.6.0" />
     <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="10.0.0-rc.1.25451.107" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0-rc.1.25451.107" />


### PR DESCRIPTION
Remove package version override for KubernetesClient as this is resolved in Aspire 9.5.
