### PR TITLE
Fix connect-src CSP

### DIFF
--- a/src/Website/appsettings.json
+++ b/src/Website/appsettings.json
@@ -26,6 +26,7 @@
       ],
       "connect-src": [
         "api.github.com",
+        "cdnjs.cloudflare.com",
         "dc.services.visualstudio.com",
         "region1.google-analytics.com",
         "stats.g.doubleclick.net",


### PR DESCRIPTION
Allow downloading source maps from cdnjs.cloudflare.com.
