### PR TITLE
Refactor use of secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,10 @@ jobs:
       CONTAINER_REGISTRY: ${{ github.repository_owner }}.azurecr.io
       PUBLISH_CONTAINER: ${{ github.event.repository.fork == false && ((github.ref_name == github.event.repository.default_branch) || (github.actor == github.repository_owner)) && matrix.os-name == 'linux' }}
 
+    environment:
+      name: build
+      deployment: false
+
     outputs:
       application-name: ${{ env.AZURE_WEBAPP_NAME }}
       container-registry: ${{ env.CONTAINER_REGISTRY }}
@@ -109,7 +113,6 @@ jobs:
       uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       with:
         flags: ${{ matrix.os-name }}
-        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload test results to Codecov
       uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
@@ -117,15 +120,19 @@ jobs:
       with:
         flags: ${{ matrix.os-name }}
         report_type: test_results
-        token: ${{ secrets.CODECOV_TOKEN }}
 
-    - name: Docker log in
-      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+    - name: Azure log in
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
       if: env.PUBLISH_CONTAINER == 'true'
       with:
-        registry: ${{ env.CONTAINER_REGISTRY }}
-        username: ${{ secrets.ACR_REGISTRY_USERNAME }}
-        password: ${{ secrets.ACR_REGISTRY_PASSWORD }}
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+    - name: Log in to Azure Container Registry
+      shell: pwsh
+      if: env.PUBLISH_CONTAINER == 'true'
+      run: az acr login --name ${env:GITHUB_REPOSITORY_OWNER}
 
     - name: Publish container
       id: publish-container

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -20,8 +20,14 @@ jobs:
       group: ${{ github.workflow }}
       cancel-in-progress: false
 
+    environment:
+      name: container-scan
+      deployment: false
+
     permissions:
+      actions: write
       contents: read
+      id-token: write
       security-events: write
 
     steps:
@@ -38,6 +44,17 @@ jobs:
           persist-credentials: false
           show-progress: false
 
+      - name: Azure log in
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Log in to Azure Container Registry
+        shell: pwsh
+        run: az acr login --name ${env:GITHUB_REPOSITORY_OWNER}
+
       - name: Configure Trivy
         id: configure
         shell: pwsh
@@ -50,8 +67,6 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
-          TRIVY_USERNAME: ${{ secrets.TRIVY_USERNAME }}
-          TRIVY_PASSWORD: ${{ secrets.TRIVY_PASSWORD }}
         with:
           image-ref: ${{ steps.configure.outputs.container-image }}
           format: 'sarif'
@@ -70,8 +85,6 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
-          TRIVY_USERNAME: ${{ secrets.TRIVY_USERNAME }}
-          TRIVY_PASSWORD: ${{ secrets.TRIVY_PASSWORD }}
         with:
           image-ref: ${{ steps.configure.outputs.container-image }}
           format: 'json'
@@ -136,5 +149,5 @@ jobs:
           github.event_name == 'schedule' &&
           steps.check-for-vulnerabilities.outputs.has-vulnerabilities == 'true'
         env:
-          GH_TOKEN: ${{ secrets.COSTELLOBOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh workflow run build.yml

--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -13,6 +13,9 @@ jobs:
       group: ${{ github.workflow }}
       cancel-in-progress: false
 
+    permissions:
+      id-token: write
+
     steps:
 
       - name: Harden runner
@@ -20,13 +23,21 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Get GitHub token
+        id: get-github-token
+        if: github.event.repository.fork == false
+        # zizmor: ignore[ref-version-mismatch] False positive
+        uses: martincostello/github-automation/actions/get-github-token@16711f5c6f94e59ee14b83697acb675be1528856 # get-github-token/v4.1.0
+        with:
+          profile-name: write
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           filter: 'tree:0'
           persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
           show-progress: false
-          token: ${{ secrets.COSTELLOBOT_TOKEN }}
+          token: ${{ steps.get-github-token.outputs.token }}
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -89,7 +100,7 @@ jobs:
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
           HEAD_BRANCH: ${{ steps.push-changes.outputs.branch-name }}
         with:
-          github-token: ${{ secrets.COSTELLOBOT_TOKEN }}
+          github-token: ${{ steps.get-github-token.outputs.token }}
           script: |
             const { repo, owner } = context.repo;
             const workflowUrl = `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -5,7 +5,5 @@ rules:
     disable: true
   dependabot-cooldown:
     disable: true
-  secrets-outside-env:
-    disable: true
   undocumented-permissions:
     disable: true


### PR DESCRIPTION
- Use OIDC to authenticate with Azure.
- Use GitHub token broker.
- Scope all secrets to environments.
- Use GITHUB_TOKEN to dispatch workflow.
- Remove codecov token.

