### PR TITLE
Performance improvements

### DIFF
--- a/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/Website/Middleware/CustomHttpHeadersMiddleware.cs
@@ -238,15 +238,7 @@ public sealed class CustomHttpHeadersMiddleware
             return string.Empty;
         }
 
-        var builder = new StringBuilder(baseUri.Host);
-
-        if (!baseUri.IsDefaultPort)
-        {
-            builder.Append(':')
-                   .Append(baseUri.Port);
-        }
-
-        return builder.ToString();
+        return baseUri.IsDefaultPort ? baseUri.Host : $"{baseUri.Host}:{baseUri.Port}";
     }
 
     /// <summary>

--- a/src/Website/Slices/_Meta.cshtml
+++ b/src/Website/Slices/_Meta.cshtml
@@ -5,6 +5,7 @@
     bool renderGA = string.Equals(Config.AzureEnvironment(), "production", StringComparison.OrdinalIgnoreCase);
     var options = Options.Value;
     var request = HttpContext!.Request;
+    var thumbnailUrl = request.CdnContent("martin_small-v3.png", options);
 }
 <title>@(Model.Title)</title>
 <meta http-equiv="cache-control" content="no-cache, no-store" />
@@ -23,9 +24,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta property="fb:profile_id" content="@(Model.Facebook)" />
 <meta property="og:description" content="@(Model.Description)" />
-<meta property="og:image" content="@(request.CdnContent("martin_small-v3.png", options))" />
+<meta property="og:image" content="@(thumbnailUrl)" />
 <meta property="og:image:type" content="image/png" />
-<meta name="twitter:image" content="@(request.CdnContent("martin_small-v3.png", options))" />
+<meta name="twitter:image" content="@(thumbnailUrl)" />
 <meta name="twitter:image:alt" content="@(Model.Author)" />
 <meta property="og:locale" content="en_GB" />
 <meta property="og:site_name" content="@(Model.SiteName)" />

--- a/src/Website/WebsiteBuilder.cs
+++ b/src/Website/WebsiteBuilder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.IO.Compression;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -20,6 +21,14 @@ namespace MartinCostello.Website;
 /// </summary>
 public static class WebsiteBuilder
 {
+    private static readonly string AspNetCoreVersion =
+        typeof(HttpContext).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
+
+    private static readonly string RuntimeVersion =
+        typeof(object).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
+
+    private static readonly long StartedAt = Stopwatch.GetTimestamp();
+
     /// <summary>
     /// Adds website services to the specified <see cref="WebApplicationBuilder"/>.
     /// </summary>
@@ -172,16 +181,14 @@ public static class WebsiteBuilder
                     ["is64BitProcess"] = Environment.Is64BitProcess,
                     ["isNativeAoT"] = !RuntimeFeature.IsDynamicCodeSupported,
                     ["isPrivilegedProcess"] = Environment.IsPrivilegedProcess,
+                    ["uptime"] = Stopwatch.GetElapsedTime(StartedAt).ToString(@"%d\.hh\:mm\:ss", CultureInfo.InvariantCulture),
                 },
                 ["dotnetVersions"] = new JsonObject()
                 {
-                    ["runtime"] = GetVersion<object>(),
-                    ["aspNetCore"] = GetVersion<HttpContext>(),
+                    ["runtime"] = RuntimeVersion,
+                    ["aspNetCore"] = AspNetCoreVersion,
                 },
             };
-
-            static string GetVersion<T>()
-                => typeof(T).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
         });
 
         app.UseCookiePolicy(new()


### PR DESCRIPTION
- Avoid reflection for each `/version` call.
- Avoid creating the same string twice.
- Avoid allocating a `StringBuilder`.
- Add uptime to `/version` response.
